### PR TITLE
Allow timestamps for set of values

### DIFF
--- a/src/ThingsBoard.cpp
+++ b/src/ThingsBoard.cpp
@@ -25,6 +25,9 @@ bool Telemetry::serializeKeyval(JsonVariant &jsonObj) const {
       case TYPE_STR:
         jsonObj[m_key] = m_value.str;
       break;
+	  case TYPE_LONG:
+        jsonObj[m_key] = m_value.lng;
+      break;
       default:
       break;
     }
@@ -41,6 +44,9 @@ bool Telemetry::serializeKeyval(JsonVariant &jsonObj) const {
       break;
       case TYPE_STR:
         return jsonObj.set(m_value.str);
+      break;
+	  case TYPE_LONG:
+        return jsonObj.set(m_value.lng);
       break;
       default:
       break;


### PR DESCRIPTION
Timestamps (ts) can be set for given values. If the value is not set as parameter or is 0, the behavior is as before. Maybe it might be necessary to add #ifdef for the case where 64bit integer are not supported such that the value is simple not set or 32bit is allowed and "000" is added after serialization,
Note: long long needs to be active for ArduinoJson.