### PR TITLE
More flexible RPC and Attributes subscription.

### DIFF
--- a/examples/0002-arduino_rpc/0002-arduino_rpc.ino
+++ b/examples/0002-arduino_rpc/0002-arduino_rpc.ino
@@ -45,7 +45,7 @@ void setup() {
 // Processes function for RPC call "example_set_temperature"
 // RPC_Data is a JSON variant, that can be queried using operator[]
 // See https://arduinojson.org/v5/api/jsonvariant/subscript/ for more details
-RPC_Response processTemperatureChange(const RPC_Data &data)
+void processTemperatureChange(const RPC_Data &data, RPC_Response &resp)
 {
   Serial.println("Received the set temperature RPC method");
 
@@ -57,13 +57,14 @@ RPC_Response processTemperatureChange(const RPC_Data &data)
   Serial.println(example_temperature);
 
   // Just an response example
-  return RPC_Response("example_response", 42);
+  JsonObject r  = resp.to<JsonObject>();
+  r["example_response"] = 42;
 }
 
 // Processes function for RPC call "example_set_switch"
 // RPC_Data is a JSON variant, that can be queried using operator[]
 // See https://arduinojson.org/v5/api/jsonvariant/subscript/ for more details
-RPC_Response processSwitchChange(const RPC_Data &data)
+void processSwitchChange(const RPC_Data &data, RPC_Response &resp)
 {
   Serial.println("Received the set switch method");
 
@@ -75,7 +76,8 @@ RPC_Response processSwitchChange(const RPC_Data &data)
   Serial.println(switch_state);
 
   // Just an response example
-  return RPC_Response("example_response", 22.02);
+  JsonObject r  = resp.to<JsonObject>();
+  r["example_response"] = 22.02;
 }
 
 const size_t callbacks_size = 2;

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -22,14 +22,10 @@ class ThingsBoardDefaultLogger;
 
 // Telemetry record class, allows to store different data using common interface.
 class Telemetry {
-  template <size_t PayloadSize = Default_Payload,
-            size_t MaxFieldsAmt = Default_Fields_Amt,
-            typename Logger = ThingsBoardDefaultLogger>
-  friend class ThingsBoardSized;
+  template <size_t PayloadSize, size_t MaxFieldsAmt, typename Logger>
+    friend class ThingsBoardSized;
 #ifndef ESP8266
-  template <size_t PayloadSize = Default_Payload,
-            size_t MaxFieldsAmt = Default_Fields_Amt,
-            typename Logger = ThingsBoardDefaultLogger>
+  template <size_t PayloadSize, size_t MaxFieldsAmt, typename Logger>
   friend class ThingsBoardHttpSized;
 #endif
 public:
@@ -123,7 +119,9 @@ public:
 };
 
 // ThingsBoardSized client class
-template <size_t PayloadSize, size_t MaxFieldsAmt, typename Logger>
+template <size_t PayloadSize = Default_Payload,
+          size_t MaxFieldsAmt = Default_Fields_Amt,
+          typename Logger = ThingsBoardDefaultLogger>
 class ThingsBoardSized
 {
 public:
@@ -451,7 +449,9 @@ ThingsBoardSized<PayloadSize, MaxFieldsAmt, Logger> *ThingsBoardSized<PayloadSiz
 #ifndef ESP8266
 
 // ThingsBoard HTTP client class
-template <size_t PayloadSize, size_t MaxFieldsAmt, typename Logger>
+template <size_t PayloadSize = Default_Payload,
+          size_t MaxFieldsAmt = Default_Fields_Amt,
+          typename Logger = ThingsBoardDefaultLogger>
 class ThingsBoardHttpSized
 {
 public:


### PR DESCRIPTION
### Hi TB team!

I've recently faced a problem with **ThingsBoard-Arduino-MQTT-SDK** when tried to connect "Knob control" widget to my esp8266 board. So I changed RPC callback signature to make callbcaks more flexible and enable any RPC-widgets to interact with **ThingsBoard-Arduino-MQTT-SDK**.

I've also added Attributes subscription methods to ThingsBoardSized class.

I hope you merge these changes.

Best regards,
Paul.