### PR TITLE
Fixed RPC Parameters EmptyInput

### DIFF
--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -703,9 +703,7 @@ class ThingsBoardSized
           return;
         }
         const JsonObject &data = jsonBuffer.template as<JsonObject>();
-
         const char *methodName = data["method"];
-        const char *params = data["params"];
 
         if (methodName) {
           Logger::log("received RPC:");
@@ -726,21 +724,12 @@ class ThingsBoardSized
               Logger::log("no parameters passed with RPC, passing null JSON");
             } else {
               Logger::log("params:");
-              Logger::log(params);
+              Logger::log(data["params"].as<String>().c_str());
             }
-
-            // deserialize params
-            StaticJsonDocument<JSON_OBJECT_SIZE(MaxFieldsAmt)> doc;
-            DeserializationError err_param = deserializeJson(doc, params);
-            if (err_param) {
-              Logger::log("unable to de-serialize params: ");
-              Logger::log(err_param.c_str());
-            }
-            const JsonObject &param = doc.template as<JsonObject>();
 
             // Getting non-existing field from JSON should automatically
             // set JSONVariant to null
-            r = m_rpcCallbacks[i].m_cb(param);
+            r = m_rpcCallbacks[i].m_cb(data["params"]);
             break;
           }
         }


### PR DESCRIPTION
It seems that with thingsboard 3.3 the request payload changed breaking RPC Parameters, requests sent no longer need to be deserialized.

3.3
`{ "method": "rpcCommand", "params": { "action": "restart" }, "persistent": false, "timeout": 5000 }`
3.2
`{ "method": "rpcCommand", "params": "{\n \"action\": \"restart\"\n}", "timeout": 5000 }`