### PR TITLE
Feat improved update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 
 # Arduino ThingsBoard SDK
 
+[![MIT license](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](https://lbesson.mit-license.org/)
+[![ESP32](https://img.shields.io/badge/ESP-32-green.svg?style=flat-square)](https://www.espressif.com/en/products/socs/esp32)
+[![ESP8266](https://img.shields.io/badge/ESP-8266-blue.svg?style=flat-square)](https://www.espressif.com/en/products/socs/esp8266)
 [![Build Status](https://travis-ci.org/thingsboard/ThingsBoard-Arduino-MQTT-SDK.svg?branch=master)](https://travis-ci.org/thingsboard/ThingsBoard-Arduino-MQTT-SDK)
+[![GitHub release](https://img.shields.io/github/release/thingsboard/thingsboard-arduino-sdk/all.svg?style=flat-square)](https://github.com/thingsboard/thingsboard-arduino-sdk/releases/)
+[![GitHub downloads](https://img.shields.io/github/downloads/thingsboard/thingsboard-arduino-sdk/all.svg?style=flat-square)](https://github.com/thingsboard/thingsboard-arduino-sdk/releases/)
 
 This library provides access to ThingsBoard platform over MQTT protocol.
 
@@ -24,6 +29,12 @@ Following dependencies must be installed, too:
  - [Telemetry data upload](https://thingsboard.io/docs/reference/mqtt-api/#telemetry-upload-api)
  - [Device attribute publish](https://thingsboard.io/docs/reference/mqtt-api/#publish-attribute-update-to-the-server)
  - [Server-side RPC](https://thingsboard.io/docs/reference/mqtt-api/#server-side-rpc)
+ - [Attribute update subscription](https://thingsboard.io/docs/reference/mqtt-api/#subscribe-to-attribute-updates-from-the-server)
+ - [Device provisioning](https://thingsboard.io/docs/reference/mqtt-api/#device-provisioning)
+ - [Device claiming](https://thingsboard.io/docs/reference/mqtt-api/#claiming-devices)
+ - [Firmware OTA update](https://thingsboard.io/docs/reference/mqtt-api/#firmware-api)
+
+Example implementations for all features can be found in the examples folder.
 
 ## Troubleshooting
 

--- a/examples/0002-arduino_rpc/0002-arduino_rpc.ino
+++ b/examples/0002-arduino_rpc/0002-arduino_rpc.ino
@@ -122,7 +122,6 @@ void loop() {
     // Perform a subscription. All consequent data processing will happen in
     // processTemperatureChange() and processSwitchChange() functions,
     // as denoted by callbacks vector.
-    tb.setup_callback();
     if (!tb.RPC_Subscribe(callbacks)) {
       Serial.println("Failed to subscribe for RPC");
       return;

--- a/examples/0002-arduino_rpc/0002-arduino_rpc.ino
+++ b/examples/0002-arduino_rpc/0002-arduino_rpc.ino
@@ -78,8 +78,7 @@ RPC_Response processSwitchChange(const RPC_Data &data)
   return RPC_Response("example_response", 22.02);
 }
 
-const size_t callbacks_size = 2;
-RPC_Callback callbacks[callbacks_size] = {
+const std::vector<RPC_Callback> callbacks = {
   { "example_set_temperature",    processTemperatureChange },
   { "example_set_switch",         processSwitchChange }
 };
@@ -122,8 +121,9 @@ void loop() {
 
     // Perform a subscription. All consequent data processing will happen in
     // processTemperatureChange() and processSwitchChange() functions,
-    // as denoted by callbacks[] array.
-    if (!tb.RPC_Subscribe(callbacks, callbacks_size)) {
+    // as denoted by callbacks vector.
+    tb.setup_callback();
+    if (!tb.RPC_Subscribe(callbacks)) {
       Serial.println("Failed to subscribe for RPC");
       return;
     }

--- a/examples/0006-esp8266_process_shared_attribute_update/0006-esp8266_process_shared_attribute_update.ino
+++ b/examples/0006-esp8266_process_shared_attribute_update/0006-esp8266_process_shared_attribute_update.ino
@@ -42,9 +42,7 @@ void processSharedAttributeUpdate(const Shared_Attribute_Data &data) {
   Serial.println(buffer);
 }
 
-Shared_Attribute_Callback callbacks[1] = {
-  processSharedAttributeUpdate
-};
+const Shared_Attribute_Callback callback(processSharedAttributeUpdate);
 
 
 void loop() {
@@ -69,8 +67,8 @@ void loop() {
 
   if (!subscribed) {
     Serial.println("Subscribing for shared attribute updates...");
-
-    if (!tb.Shared_Attributes_Subscribe(callbacks, 1)) {
+    tb.setup_callback();
+    if (!tb.Shared_Attributes_Subscribe(callback)) {
       Serial.println("Failed to subscribe for shared attribute updates");
       return;
     }

--- a/examples/0006-esp8266_process_shared_attribute_update/0006-esp8266_process_shared_attribute_update.ino
+++ b/examples/0006-esp8266_process_shared_attribute_update/0006-esp8266_process_shared_attribute_update.ino
@@ -42,10 +42,7 @@ void processSharedAttributeUpdate(const Shared_Attribute_Data &data) {
   Serial.println(buffer);
 }
 
-// Boolean shows wheter the shared attribute callback is used for a sharedKey request or not.
-// If it is it will be removed from the callback vector to increase size as soon as it has been called.
-const Shared_Attribute_Callback callback(false, processSharedAttributeUpdate);
-
+const Shared_Attribute_Callback callback(processSharedAttributeUpdate);
 
 void loop() {
   delay(1000);

--- a/examples/0006-esp8266_process_shared_attribute_update/0006-esp8266_process_shared_attribute_update.ino
+++ b/examples/0006-esp8266_process_shared_attribute_update/0006-esp8266_process_shared_attribute_update.ino
@@ -66,7 +66,6 @@ void loop() {
 
   if (!subscribed) {
     Serial.println("Subscribing for shared attribute updates...");
-    tb.setup_callback();
     if (!tb.Shared_Attributes_Subscribe(callback)) {
       Serial.println("Failed to subscribe for shared attribute updates");
       return;

--- a/examples/0006-esp8266_process_shared_attribute_update/0006-esp8266_process_shared_attribute_update.ino
+++ b/examples/0006-esp8266_process_shared_attribute_update/0006-esp8266_process_shared_attribute_update.ino
@@ -36,7 +36,7 @@ void processSharedAttributeUpdate(const Shared_Attribute_Data &data) {
     Serial.println(it->value().as<char*>()); // We have to parse data by it's type in the current example we will show here only char data
   }
 
-  int jsonSize = measureJson(data) + 1;
+  int jsonSize = JSON_STRING_SIZE(measureJson(data));
   char buffer[jsonSize];
   serializeJson(data, buffer, jsonSize);
   Serial.println(buffer);

--- a/examples/0006-esp8266_process_shared_attribute_update/0006-esp8266_process_shared_attribute_update.ino
+++ b/examples/0006-esp8266_process_shared_attribute_update/0006-esp8266_process_shared_attribute_update.ino
@@ -42,7 +42,9 @@ void processSharedAttributeUpdate(const Shared_Attribute_Data &data) {
   Serial.println(buffer);
 }
 
-const Shared_Attribute_Callback callback(processSharedAttributeUpdate);
+// Boolean shows wheter the shared attribute callback is used for a sharedKey request or not.
+// If it is it will be removed from the callback vector to increase size as soon as it has been called.
+const Shared_Attribute_Callback callback(false, processSharedAttributeUpdate);
 
 
 void loop() {

--- a/examples/0008-esp8266_provision_device/0008-esp8266_provision_device.ino
+++ b/examples/0008-esp8266_provision_device/0008-esp8266_provision_device.ino
@@ -52,7 +52,7 @@ void setup() {
 
 void processProvisionResponse(const Provision_Data &data) {
   Serial.println("Received device provision response");
-  int jsonSize = measureJson(data) + 1;
+  int jsonSize = JSON_STRING_SIZE(measureJson(data));
   char buffer[jsonSize];
   serializeJson(data, buffer, jsonSize);
   Serial.println(buffer);

--- a/examples/0008-esp8266_provision_device/0008-esp8266_provision_device.ino
+++ b/examples/0008-esp8266_provision_device/0008-esp8266_provision_device.ino
@@ -97,7 +97,6 @@ void loop() {
           Serial.println("Failed to connect");
           return;
         }
-        tb_provision.setup_callback();
         if (tb_provision.Provision_Subscribe(provisionCallback)) {
           if (tb_provision.sendProvisionRequest(deviceName, provisionDeviceKey, provisionDeviceSecret)) {
             provisionRequestSent = true;

--- a/examples/0008-esp8266_provision_device/0008-esp8266_provision_device.ino
+++ b/examples/0008-esp8266_provision_device/0008-esp8266_provision_device.ino
@@ -97,6 +97,7 @@ void loop() {
           Serial.println("Failed to connect");
           return;
         }
+        tb_provision.setup_callback();
         if (tb_provision.Provision_Subscribe(provisionCallback)) {
           if (tb_provision.sendProvisionRequest(deviceName, provisionDeviceKey, provisionDeviceSecret)) {
             provisionRequestSent = true;

--- a/examples/0009-esp8266_esp32_process_OTA_MQTT/0009-esp8266_esp32_process_OTA_MQTT.ino
+++ b/examples/0009-esp8266_esp32_process_OTA_MQTT/0009-esp8266_esp32_process_OTA_MQTT.ino
@@ -81,7 +81,6 @@ void loop() {
     }
 
     Serial.println("Firwmare Update...");
-    tb.setup_callback();
     tb.Firmware_OTA_Subscribe();
     if (tb.Firmware_Update(CURRENT_FIRMWARE_TITLE, CURRENT_FIRMWARE_VERSION)) {
       Serial.println("Done, Reboot now");

--- a/examples/0009-esp8266_esp32_process_OTA_MQTT/0009-esp8266_esp32_process_OTA_MQTT.ino
+++ b/examples/0009-esp8266_esp32_process_OTA_MQTT/0009-esp8266_esp32_process_OTA_MQTT.ino
@@ -55,6 +55,20 @@ void reconnect() {
   }
 }
 
+void UpdatedCallback(const bool& success) {
+  if (success) {
+    Serial.println("Done, Reboot now");
+#if defined(ESP8266)
+    ESP.restart();
+#elif defined(ESP32)
+    esp_restart();
+#endif
+  }
+  else {
+    Serial.println("No new firmware");
+  }
+}
+
 void setup() {
   // initialize serial for debugging
   Serial.begin(SERIAL_DEBUG_BAUD);
@@ -81,19 +95,7 @@ void loop() {
     }
 
     Serial.println("Firwmare Update...");
-    tb.Firmware_OTA_Subscribe();
-    if (tb.Firmware_Update(CURRENT_FIRMWARE_TITLE, CURRENT_FIRMWARE_VERSION)) {
-      Serial.println("Done, Reboot now");
-#if defined(ESP8266)
-      ESP.restart();
-#elif defined(ESP32)
-      esp_restart();
-#endif
-    }
-    else {
-      Serial.println("No new firmware");
-    }
-    tb.Firmware_OTA_Unsubscribe();
+    tb.Start_Firmware_Update(CURRENT_FIRMWARE_TITLE, CURRENT_FIRMWARE_VERSION, UpdatedCallback);
   }
 
   tb.loop();

--- a/examples/0009-esp8266_esp32_process_OTA_MQTT/0009-esp8266_esp32_process_OTA_MQTT.ino
+++ b/examples/0009-esp8266_esp32_process_OTA_MQTT/0009-esp8266_esp32_process_OTA_MQTT.ino
@@ -81,6 +81,7 @@ void loop() {
     }
 
     Serial.println("Firwmare Update...");
+    tb.setup_callback();
     tb.Firmware_OTA_Subscribe();
     if (tb.Firmware_Update(CURRENT_FIRMWARE_TITLE, CURRENT_FIRMWARE_VERSION)) {
       Serial.println("Done, Reboot now");

--- a/src/ThingsBoard.cpp
+++ b/src/ThingsBoard.cpp
@@ -10,7 +10,7 @@
 
 /*----------------------------------------------------------------------------*/
 
-bool Telemetry::serializeKeyval(JsonVariant &jsonObj) const {
+const bool Telemetry::serializeKeyval(JsonVariant &jsonObj) const {
   if (m_key) {
     switch (m_type) {
       case TYPE_BOOL:

--- a/src/ThingsBoard.cpp
+++ b/src/ThingsBoard.cpp
@@ -48,8 +48,3 @@ bool Telemetry::serializeKeyval(JsonVariant &jsonObj) const {
   }
   return true;
 }
-
-void ThingsBoardDefaultLogger::log(const char *msg) {
-  Serial.print(F("[TB] "));
-  Serial.println(msg);
-}

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -207,11 +207,12 @@ class ThingsBoardSized
     // Initializes ThingsBoardSized class with network client.
     // Certain private members can not be set in the constructor initalizor list,
     // because using 2 instances of the ThingsBoard class (for example. provision and connected client)
-    // will result in the variables being reset betwenn method calls. Resulting in weird behaviour.
+    // will result in the variables being reset between method calls. Resulting in unexpected behaviour.
     inline ThingsBoardSized(Client &client)
       : m_client(client)
       , m_requestId(0)
     {
+      m_client.setBufferSize(PayloadSize);
       // Reserve size of both m_sharedAttributeUpdateCallbacks, rpcCallbacks and m_sharedAttributeRequestCallbacks beforehand for performance reasons.
       m_rpcCallbacks.reserve(MaxFieldsAmt);
       m_sharedAttributeUpdateCallbacks.reserve(MaxFieldsAmt);
@@ -354,6 +355,7 @@ class ThingsBoardSized
       uint32_t json_size = measureJson(jsonObject) + 1U;
       char json[json_size];
       serializeJson(jsonObject, json, json_size);
+      Logger::log(json);
       return m_client.publish("v1/devices/me/telemetry", json);
     }
 

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -294,14 +294,14 @@ class ThingsBoardSized
       StaticJsonDocument<JSON_OBJECT_SIZE(1)> requestBuffer;
       JsonObject resp_obj = requestBuffer.to<JsonObject>();
 
-      resp_obj["secretKey"] = secretKey;
-      resp_obj["durationMs"] = durationMs;
+      resp_obj[PSTR("secretKey")] = secretKey;
+      resp_obj[PSTR("durationMs")] = durationMs;
 
       uint8_t objectSize = JSON_STRING_SIZE(measureJson(requestBuffer));
       char responsePayload[objectSize];
       serializeJson(resp_obj, responsePayload, objectSize);
 
-      return m_client.publish("v1/devices/me/claim", responsePayload);
+      return m_client.publish(PSTR("v1/devices/me/claim"), responsePayload);
     }
 
     // Provisioning API
@@ -310,9 +310,9 @@ class ThingsBoardSized
       StaticJsonDocument<JSON_OBJECT_SIZE(3)> requestBuffer;
       JsonObject requestObject = requestBuffer.to<JsonObject>();
 
-      requestObject["deviceName"] = deviceName;
-      requestObject["provisionDeviceKey"] = provisionDeviceKey;
-      requestObject["provisionDeviceSecret"] = provisionDeviceSecret;
+      requestObject[PSTR("deviceName")] = deviceName;
+      requestObject[PSTR("provisionDeviceKey")] = provisionDeviceKey;
+      requestObject[PSTR("provisionDeviceSecret")] = provisionDeviceSecret;
 
       uint8_t objectSize = JSON_STRING_SIZE(measureJson(requestBuffer));
       char requestPayload[objectSize];
@@ -320,7 +320,7 @@ class ThingsBoardSized
 
       Logger::log(PSTR("Provision request:"));
       Logger::log(requestPayload);
-      return m_client.publish("/provision/request", requestPayload);
+      return m_client.publish(PSTR("/provision/request"), requestPayload);
     }
 
 #endif
@@ -361,7 +361,7 @@ class ThingsBoardSized
 
     // Sends custom JSON telemetry string to the ThingsBoard.
     inline const bool sendTelemetryJson(const char *json) {
-      return m_client.publish("v1/devices/me/telemetry", json);
+      return m_client.publish(PSTR("v1/devices/me/telemetry"), json);
     }
 
     // Sends custom JSON telemetry JsonObject to the ThingsBoard.
@@ -369,7 +369,7 @@ class ThingsBoardSized
       uint32_t json_size = JSON_STRING_SIZE(measureJson(jsonObject));
       char json[json_size];
       serializeJson(jsonObject, json, json_size);
-      return m_client.publish("v1/devices/me/telemetry", json);
+      return m_client.publish(PSTR("v1/devices/me/telemetry"), json);
     }
 
     //----------------------------------------------------------------------------
@@ -428,7 +428,7 @@ class ThingsBoardSized
         Logger::log(PSTR("Too many rpc subscriptions, increase MaxFieldsAmt or unsubscribe."));
         return false;
       }
-      if (!m_client.subscribe("v1/devices/me/rpc/request/+")) {
+      if (!m_client.subscribe(PSTR("v1/devices/me/rpc/request/+"))) {
         return false;
       }
 
@@ -443,7 +443,7 @@ class ThingsBoardSized
         Logger::log(PSTR("Too many rpc subscriptions, increase MaxFieldsAmt or unsubscribe."));
         return false;
       }
-      if (!m_client.subscribe("v1/devices/me/rpc/request/+")) {
+      if (!m_client.subscribe(PSTR("v1/devices/me/rpc/request/+"))) {
         return false;
       }
 
@@ -455,7 +455,7 @@ class ThingsBoardSized
     inline const bool RPC_Unsubscribe() {
       // Empty all callbacks.
       m_rpcCallbacks.clear();
-      return m_client.unsubscribe("v1/devices/me/rpc/request/+");
+      return m_client.unsubscribe(PSTR("v1/devices/me/rpc/request/+"));
     }
 
     //----------------------------------------------------------------------------
@@ -600,8 +600,8 @@ class ThingsBoardSized
       StaticJsonDocument<JSON_OBJECT_SIZE(2)> currentFirmwareInfo;
       JsonObject currentFirmwareInfoObject = currentFirmwareInfo.to<JsonObject>();
 
-      currentFirmwareInfoObject["current_fw_title"] = currFwTitle;
-      currentFirmwareInfoObject["current_fw_version"] = currFwVersion;
+      currentFirmwareInfoObject[PSTR("current_fw_title")] = currFwTitle;
+      currentFirmwareInfoObject[PSTR("current_fw_version")] = currFwVersion;
       return sendTelemetryJson(currentFirmwareInfoObject);
     }
 
@@ -610,12 +610,12 @@ class ThingsBoardSized
       StaticJsonDocument<JSON_OBJECT_SIZE(1)> currentFirmwareState;
       JsonObject currentFirmwareStateObject = currentFirmwareState.to<JsonObject>();
 
-      currentFirmwareStateObject["current_fw_state"] = currFwState;
+      currentFirmwareStateObject[PSTR("current_fw_state")] = currFwState;
       return sendTelemetryJson(currentFirmwareStateObject);
     }
 
     inline const bool Firmware_OTA_Subscribe() {
-      if (!m_client.subscribe("v2/fw/response/#")) {
+      if (!m_client.subscribe(PSTR("v2/fw/response/#"))) {
         return false;
       }
 
@@ -623,7 +623,7 @@ class ThingsBoardSized
     }
 
     inline const bool Firmware_OTA_Unsubscribe() {
-      if (!m_client.unsubscribe("v2/fw/response/#")) {
+      if (!m_client.unsubscribe(PSTR("v2/fw/response/#"))) {
         return false;
       }
 
@@ -657,7 +657,7 @@ class ThingsBoardSized
       // Remove latest not needed ,
       sharedKeys.pop_back();
 
-      requestObject["sharedKeys"] = sharedKeys.c_str();
+      requestObject[PSTR("sharedKeys")] = sharedKeys.c_str();
       int objectSize = measureJson(requestBuffer) + 1;
       char buffer[objectSize];
       serializeJson(requestObject, buffer, objectSize);
@@ -677,7 +677,7 @@ class ThingsBoardSized
         Logger::log(PSTR("Too many shared attribute update callback subscriptions, increase MaxFieldsAmt or unsubscribe."));
         return false;
       }
-      if (!m_client.subscribe("v1/devices/me/attributes")) {
+      if (!m_client.subscribe(PSTR("v1/devices/me/attributes"))) {
         return false;
       }
 
@@ -692,7 +692,7 @@ class ThingsBoardSized
         Logger::log(PSTR("Too many shared attribute update callback subscriptions, increase MaxFieldsAmt or unsubscribe."));
         return false;
       }
-      if (!m_client.subscribe("v1/devices/me/attributes")) {
+      if (!m_client.subscribe(PSTR("v1/devices/me/attributes"))) {
         return false;
       }
 
@@ -704,7 +704,7 @@ class ThingsBoardSized
     inline const bool Shared_Attributes_Unsubscribe() {
       // Empty all callbacks.
       m_sharedAttributeUpdateCallbacks.clear();
-      if (!m_client.unsubscribe("v1/devices/me/attributes")) {
+      if (!m_client.unsubscribe(PSTR("v1/devices/me/attributes"))) {
         return false;
       }
       return true;
@@ -717,7 +717,7 @@ class ThingsBoardSized
 
 #if defined(ESP8266) || defined(ESP32) || defined(ARDUINO_AVR_MEGA)
     inline const bool Provision_Subscribe(const Provision_Callback callback) {
-      if (!m_client.subscribe("/provision/response")) {
+      if (!m_client.subscribe(PSTR("/provision/response"))) {
         return false;
       }
       m_provisionCallback = callback;
@@ -725,7 +725,7 @@ class ThingsBoardSized
     }
 
     inline const bool Provision_Unsubscribe() {
-      if (!m_client.unsubscribe("/provision/response")) {
+      if (!m_client.unsubscribe(PSTR("/provision/response"))) {
         return false;
       }
       return true;
@@ -753,7 +753,7 @@ class ThingsBoardSized
         Logger::log(PSTR("Too many shared attribute request callback subscriptions, increase MaxFieldsAmt."));
         return false;
       }
-      if (!m_client.subscribe("v1/devices/me/attributes/response/+")) {
+      if (!m_client.subscribe(PSTR("v1/devices/me/attributes/response/+"))) {
         return false;
       }
 
@@ -765,7 +765,7 @@ class ThingsBoardSized
     inline const bool Shared_Attributes_Request_Unsubscribe() {
       // Empty all callbacks.
       m_sharedAttributeRequestCallbacks.clear();
-      if (!m_client.unsubscribe("v1/devices/attributes/response/+")) {
+      if (!m_client.unsubscribe(PSTR("v1/devices/attributes/response/+"))) {
         return false;
       }
       return true;
@@ -806,8 +806,8 @@ class ThingsBoardSized
           return;
         }
         const JsonObject &data = jsonBuffer.template as<JsonObject>();
-        const char *methodName = data["method"];
-        const char *params = data["params"];
+        const char *methodName = data[PSTR("method")];
+        const char *params = data[PSTR("params")];
 
         if (methodName) {
           Logger::log(PSTR("received RPC:"));
@@ -837,8 +837,8 @@ class ThingsBoardSized
           //if failed to de-serialize params then send JsonObject instead
           Logger::log(PSTR("params:"));
           if (err_param) {
-            Logger::log(data["params"].as<String>().c_str());
-            r = callback.m_cb(data["params"]);
+            Logger::log(data[PSTR("params")].as<String>().c_str());
+            r = callback.m_cb(data[PSTR("params")]);
           } else {
             Logger::log(params);
             const JsonObject &param = doc.template as<JsonObject>();
@@ -952,8 +952,8 @@ class ThingsBoardSized
 
       if (data && (data.size() >= 1)) {
         Logger::log(PSTR("Received shared attribute update request"));
-        if (data["shared"]) {
-          data = data["shared"];
+        if (data[PSTR("shared")]) {
+          data = data[PSTR("shared")];
         }
       } else {
         Logger::log(PSTR("Shared attribute update key not found."));
@@ -1012,8 +1012,8 @@ class ThingsBoardSized
 
       if (data && (data.size() >= 1)) {
         Logger::log(PSTR("Received shared attribute request"));
-        if (data["shared"]) {
-          data = data["shared"];
+        if (data[PSTR("shared")]) {
+          data = data[PSTR("shared")];
         }
       } else {
         Logger::log(PSTR("Shared attribute key not found."));
@@ -1022,20 +1022,20 @@ class ThingsBoardSized
 
       // Save data for firmware update
 #if defined(ESP8266) || defined(ESP32)
-      if (data["fw_title"]) {
-        m_fwTitle = data["fw_title"].as<String>();
+      if (data[PSTR("fw_title")]) {
+        m_fwTitle = data[PSTR("fw_title")].as<String>();
       }
-      if (data["fw_version"]) {
-        m_fwVersion = data["fw_version"].as<String>();
+      if (data[PSTR("fw_version")]) {
+        m_fwVersion = data[PSTR("fw_version")].as<String>();
       }
-      if (data["fw_checksum"]) {
-        m_fwChecksum = data["fw_checksum"].as<String>();
+      if (data[PSTR("fw_checksum")]) {
+        m_fwChecksum = data[PSTR("fw_checksum")].as<String>();
       }
-      if (data["fw_checksum_algorithm"]) {
-        m_fwChecksumAlgorithm = data["fw_checksum_algorithm"].as<String>();
+      if (data[PSTR("fw_checksum_algorithm")]) {
+        m_fwChecksumAlgorithm = data[PSTR("fw_checksum_algorithm")].as<String>();
       }
-      if (data["fw_size"]) {
-        m_fwSize = data["fw_size"].as<int>();
+      if (data[PSTR("fw_size")]) {
+        m_fwSize = data[PSTR("fw_size")].as<int>();
       }
 #endif
 
@@ -1081,7 +1081,7 @@ class ThingsBoardSized
 
       Logger::log(PSTR("Received provision response"));
 
-      if (data["status"] == "SUCCESS" && data["credentialsType"] == "X509_CERTIFICATE") {
+      if (data[PSTR("status")] == "SUCCESS" && data[PSTR("credentialsType")] == "X509_CERTIFICATE") {
         Logger::log(PSTR("Provision response contains X509_CERTIFICATE credentials, it is not supported yet."));
         return;
       }

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -318,7 +318,7 @@ class ThingsBoardSized
       char requestPayload[objectSize];
       serializeJson(requestObject, requestPayload, objectSize);
 
-      Logger::log("Provision request:");
+      Logger::log(PSTR("Provision request:"));
       Logger::log(requestPayload);
       return m_client.publish("/provision/request", requestPayload);
     }
@@ -425,7 +425,7 @@ class ThingsBoardSized
     // Subscribes multiple RPC callbacks.
     inline const bool RPC_Subscribe(const std::vector<RPC_Callback>& callbacks) {
       if (m_rpcCallbacks.size() + callbacks.size() > m_rpcCallbacks.capacity()) {
-        Logger::log("Too many rpc subscriptions, increase MaxFieldsAmt or unsubscribe.");
+        Logger::log(PSTR("Too many rpc subscriptions, increase MaxFieldsAmt or unsubscribe."));
         return false;
       }
       if (!m_client.subscribe("v1/devices/me/rpc/request/+")) {
@@ -440,7 +440,7 @@ class ThingsBoardSized
     // Subscribe one RPC callback.
     inline const bool RPC_Subscribe(const RPC_Callback& callback) {
       if (m_rpcCallbacks.size() + 1 > m_rpcCallbacks.capacity()) {
-        Logger::log("Too many rpc subscriptions, increase MaxFieldsAmt or unsubscribe.");
+        Logger::log(PSTR("Too many rpc subscriptions, increase MaxFieldsAmt or unsubscribe."));
         return false;
       }
       if (!m_client.subscribe("v1/devices/me/rpc/request/+")) {
@@ -490,35 +490,35 @@ class ThingsBoardSized
 
       // Check if firmware is available for our device
       if (m_fwVersion.isEmpty() || m_fwTitle.isEmpty()) {
-        Logger::log("No firmware found !");
+        Logger::log(PSTR("No firmware found !"));
         Firmware_Send_State("NO FIRMWARE FOUND");
         return false;
       }
 
       // If firmware is the same, we do not update it
       if ((String(currFwTitle) == m_fwTitle) and (String(currFwVersion) == m_fwVersion)) {
-        Logger::log("Firmware is already up to date !");
+        Logger::log(PSTR("Firmware is already up to date !"));
         Firmware_Send_State("UP TO DATE");
         return false;
       }
 
       // If firmware title is not the same, we quit now
       if (String(currFwTitle) != m_fwTitle) {
-        Logger::log("Firmware is not for us (title is different) !");
+        Logger::log(PSTR("Firmware is not for us (title is different) !"));
         Firmware_Send_State("NO FIRMWARE FOUND");
         return false;
       }
 
       if (m_fwChecksumAlgorithm != "MD5") {
-        Logger::log("Checksum algorithm is not supported, please use MD5 only");
+        Logger::log(PSTR("Checksum algorithm is not supported, please use MD5 only"));
         Firmware_Send_State("CHKS IS NOT MD5");
         return false;
       }
 
-      Logger::log("=================================");
-      Logger::log("A new Firmware is available :");
+      Logger::log(PSTR("================================="));
+      Logger::log(PSTR("A new Firmware is available :"));
       Logger::log(String(String(currFwVersion) + " => " + m_fwVersion).c_str());
-      Logger::log("Try to download it...");
+      Logger::log(PSTR("Try to download it..."));
 
       int chunkSize = 4096; // maybe less if we don't have enough RAM
       int numberOfChunk = static_cast<int>(m_fwSize/chunkSize) + 1;
@@ -527,7 +527,7 @@ class ThingsBoardSized
 
       // Increase size of receive buffer
       if (!m_client.setBufferSize(chunkSize + 50)) {
-        Logger::log("Not enough RAM");
+        Logger::log(PSTR("Not enough RAM"));
         return false;
       }
 
@@ -555,7 +555,7 @@ class ThingsBoardSized
             else {
               nbRetry--;
               if (nbRetry == 0) {
-                Logger::log("Unable to write firmware");
+                Logger::log(PSTR("Unable to write firmware"));
                 break;
               }
             }
@@ -570,7 +570,7 @@ class ThingsBoardSized
         else {
           nbRetry--;
           if (nbRetry == 0) {
-            Logger::log("Unable to download firmware");
+            Logger::log(PSTR("Unable to download firmware"));
             break;
           }
         }
@@ -644,7 +644,7 @@ class ThingsBoardSized
 
       // Check if any sharedKeys were requested.
       if (sharedKeys.empty()) {
-        Logger::log("No keys to request were given.");
+        Logger::log(PSTR("No keys to request were given."));
         return false;
       }
 
@@ -665,7 +665,7 @@ class ThingsBoardSized
     // Subscribes multiple Shared attributes callbacks.
     inline const bool Shared_Attributes_Subscribe(const std::vector<Shared_Attribute_Callback>& callbacks) {
       if (m_sharedAttributeUpdateCallbacks.size() + callbacks.size() > m_sharedAttributeUpdateCallbacks.capacity()) {
-        Logger::log("Too many shared attribute update callback subscriptions, increase MaxFieldsAmt or unsubscribe.");
+        Logger::log(PSTR("Too many shared attribute update callback subscriptions, increase MaxFieldsAmt or unsubscribe."));
         return false;
       }
       if (!m_client.subscribe("v1/devices/me/attributes")) {
@@ -680,7 +680,7 @@ class ThingsBoardSized
     // Subscribe one Shared attributes callback.
     bool Shared_Attributes_Subscribe(const Shared_Attribute_Callback& callback) {
       if (m_sharedAttributeUpdateCallbacks.size() + 1 > m_sharedAttributeUpdateCallbacks.capacity()) {
-        Logger::log("Too many shared attribute update callback subscriptions, increase MaxFieldsAmt or unsubscribe.");
+        Logger::log(PSTR("Too many shared attribute update callback subscriptions, increase MaxFieldsAmt or unsubscribe."));
         return false;
       }
       if (!m_client.subscribe("v1/devices/me/attributes")) {
@@ -736,7 +736,7 @@ class ThingsBoardSized
     // Subscribe one Shared attributes request callback.
     inline const bool Shared_Attributes_Request_Subscribe(const Shared_Attribute_Request_Callback& callback) {
       if (m_sharedAttributeRequestCallbacks.size() + 1 > m_sharedAttributeRequestCallbacks.capacity()) {
-        Logger::log("Too many shared attribute request callback subscriptions, increase MaxFieldsAmt.");
+        Logger::log(PSTR("Too many shared attribute request callback subscriptions, increase MaxFieldsAmt."));
         return false;
       }
       if (!m_client.subscribe("v1/devices/me/attributes/response/+")) {
@@ -768,12 +768,12 @@ class ThingsBoardSized
         StaticJsonDocument<JSON_OBJECT_SIZE(1)>jsonBuffer;
         JsonVariant object = jsonBuffer.template to<JsonVariant>();
         if (t.serializeKeyval(object) == false) {
-          Logger::log("unable to serialize data");
+          Logger::log(PSTR("unable to serialize data"));
           return false;
         }
 
         if (JSON_STRING_SIZE(measureJson(jsonBuffer)) > PayloadSize) {
-          Logger::log("too small buffer for JSON data");
+          Logger::log(PSTR("too small buffer for JSON data"));
           return false;
         }
         serializeJson(object, payload, sizeof(payload));
@@ -788,7 +788,7 @@ class ThingsBoardSized
         StaticJsonDocument<JSON_OBJECT_SIZE(MaxFieldsAmt)> jsonBuffer;
         DeserializationError error = deserializeJson(jsonBuffer, payload, length);
         if (error) {
-          Logger::log("unable to de-serialize RPC");
+          Logger::log(PSTR("unable to de-serialize RPC"));
           return;
         }
         const JsonObject &data = jsonBuffer.template as<JsonObject>();
@@ -796,10 +796,10 @@ class ThingsBoardSized
         const char *params = data["params"];
 
         if (methodName) {
-          Logger::log("received RPC:");
+          Logger::log(PSTR("received RPC:"));
           Logger::log(methodName);
         } else {
-          Logger::log("RPC method is NULL");
+          Logger::log(PSTR("RPC method is NULL"));
           return;
         }
 
@@ -810,23 +810,22 @@ class ThingsBoardSized
             continue;
           }
 
-          Logger::log("calling RPC:");
+          Logger::log(PSTR("calling RPC:"));
           Logger::log(methodName);
           // Do not inform client, if parameter field is missing for some reason
           if (!data.containsKey("params")) {
-            Logger::log("no parameters passed with RPC, passing null JSON");
+            Logger::log(PSTR("no parameters passed with RPC, passing null JSON"));
           }
 
           // try to de-serialize params
           StaticJsonDocument<JSON_OBJECT_SIZE(MaxFieldsAmt)> doc;
           DeserializationError err_param = deserializeJson(doc, params);
           //if failed to de-serialize params then send JsonObject instead
+          Logger::log(PSTR("params:"));
           if (err_param) {
-            Logger::log("params:");
             Logger::log(data["params"].as<String>().c_str());
             r = callback.m_cb(data["params"]);
           } else {
-            Logger::log("params:");
             Logger::log(params);
             const JsonObject &param = doc.template as<JsonObject>();
             // Getting non-existing field from JSON should automatically
@@ -842,19 +841,19 @@ class ThingsBoardSized
       JsonVariant resp_obj = respBuffer.template to<JsonVariant>();
 
       if (r.serializeKeyval(resp_obj) == false) {
-        Logger::log("unable to serialize data");
+        Logger::log(PSTR("unable to serialize data"));
         return;
       }
 
       if (JSON_STRING_SIZE(measureJson(respBuffer)) > PayloadSize) {
-        Logger::log("too small buffer for JSON data");
+        Logger::log(PSTR("too small buffer for JSON data"));
         return;
       }
       serializeJson(resp_obj, responsePayload, sizeof(responsePayload));
 
       String responseTopic = String(topic);
       responseTopic.replace("request", "response");
-      Logger::log("response:");
+      Logger::log(PSTR("response:"));
       Logger::log(responsePayload);
       m_client.publish(responseTopic.c_str(), responsePayload);
     }
@@ -878,7 +877,7 @@ class ThingsBoardSized
 
         // Initialize Flash
         if (!Update.begin(m_fwSize)) {
-          Logger::log("Error during Update.begin");
+          Logger::log(PSTR("Error during Update.begin"));
           m_fwState = "UPDATE ERROR";
           return;
         }
@@ -886,7 +885,7 @@ class ThingsBoardSized
 
       // Write data to Flash
       if (Update.write(payload, length) != length) {
-        Logger::log("Error during Update.write");
+        Logger::log(PSTR("Error during Update.write"));
         m_fwState = "UPDATE ERROR";
         return;
       }
@@ -903,16 +902,16 @@ class ThingsBoardSized
         Logger::log(String("md5 firmware: " + m_fwChecksum).c_str());
         // Check MD5
         if (md5Str != m_fwChecksum) {
-          Logger::log("Checksum verification failed !");
+          Logger::log(PSTR("Checksum verification failed !"));
 #if defined(ESP32)
           Update.abort();
 #endif
           m_fwState = "CHECKSUM ERROR";
         }
         else {
-          Logger::log("Checksum is OK !");
+          Logger::log(PSTR("Checksum is OK !"));
           if (Update.end(true)) {
-            Logger::log("Update Success !");
+            Logger::log(PSTR("Update Success !"));
             m_fwState = "SUCCESS";
           }
         }
@@ -925,18 +924,18 @@ class ThingsBoardSized
       StaticJsonDocument<JSON_OBJECT_SIZE(MaxFieldsAmt)> jsonBuffer;
       DeserializationError error = deserializeJson(jsonBuffer, payload, length);
       if (error) {
-        Logger::log("Unable to de-serialize Shared attribute update request");
+        Logger::log(PSTR("Unable to de-serialize Shared attribute update request"));
         return;
       }
       JsonObject data = jsonBuffer.template as<JsonObject>();
 
       if (data && (data.size() >= 1)) {
-        Logger::log("Received shared attribute update request");
+        Logger::log(PSTR("Received shared attribute update request"));
         if (data["shared"]) {
           data = data["shared"];
         }
       } else {
-        Logger::log("Shared attribute update key not found.");
+        Logger::log(PSTR("Shared attribute update key not found."));
         return;
       }
 
@@ -983,18 +982,18 @@ class ThingsBoardSized
       StaticJsonDocument<JSON_OBJECT_SIZE(MaxFieldsAmt)> jsonBuffer;
       DeserializationError error = deserializeJson(jsonBuffer, payload, length);
       if (error) {
-        Logger::log("Unable to de-serialize Shared attribute request");
+        Logger::log(PSTR("Unable to de-serialize Shared attribute request"));
         return;
       }
       JsonObject data = jsonBuffer.template as<JsonObject>();
 
       if (data && (data.size() >= 1)) {
-        Logger::log("Received shared attribute request");
+        Logger::log(PSTR("Received shared attribute request"));
         if (data["shared"]) {
           data = data["shared"];
         }
       } else {
-        Logger::log("Shared attribute key not found.");
+        Logger::log(PSTR("Shared attribute key not found."));
         return;
       }
 
@@ -1044,21 +1043,21 @@ class ThingsBoardSized
     // Processes provisioning response
 #if defined(ESP8266) || defined(ESP32) || defined(ARDUINO_AVR_MEGA)
     inline void process_provisioning_response(char* topic, uint8_t* payload, unsigned int length) {
-      Logger::log("Process provisioning response");
+      Logger::log(PSTR("Process provisioning response"));
 
       StaticJsonDocument<JSON_OBJECT_SIZE(MaxFieldsAmt)> jsonBuffer;
       DeserializationError error = deserializeJson(jsonBuffer, payload, length);
       if (error) {
-        Logger::log("Unable to de-serialize provision response");
+        Logger::log(PSTR("Unable to de-serialize provision response"));
         return;
       }
 
       const JsonObject &data = jsonBuffer.template as<JsonObject>();
 
-      Logger::log("Received provision response");
+      Logger::log(PSTR("Received provision response"));
 
       if (data["status"] == "SUCCESS" && data["credentialsType"] == "X509_CERTIFICATE") {
-        Logger::log("Provision response contains X509_CERTIFICATE credentials, it is not supported yet.");
+        Logger::log(PSTR("Provision response contains X509_CERTIFICATE credentials, it is not supported yet."));
         return;
       }
 
@@ -1071,7 +1070,7 @@ class ThingsBoardSized
     // Sends array of attributes or telemetry to ThingsBoard
     inline const bool sendDataArray(const Telemetry *data, size_t data_count, bool telemetry = true) {
       if (MaxFieldsAmt < data_count) {
-        Logger::log("too much JSON fields passed");
+        Logger::log(PSTR("too much JSON fields passed"));
         return false;
       }
       char payload[PayloadSize];
@@ -1081,12 +1080,12 @@ class ThingsBoardSized
 
         for (size_t i = 0; i < data_count; ++i) {
           if (data[i].serializeKeyval(object) == false) {
-            Logger::log("unable to serialize data");
+            Logger::log(PSTR("unable to serialize data"));
             return false;
           }
         }
         if (JSON_STRING_SIZE(measureJson(jsonBuffer)) > PayloadSize) {
-          Logger::log("too small buffer for JSON data");
+          Logger::log(PSTR("too small buffer for JSON data"));
           return false;
         }
         serializeJson(object, payload, sizeof(payload));
@@ -1201,7 +1200,7 @@ class ThingsBoardHttpSized
 
       if (!m_client.connected()) {
         if (!m_client.connect(m_host, m_port)) {
-          Logger::log("connect to server failed");
+          Logger::log(PSTR("connect to server failed"));
           return false;
         }
       }
@@ -1254,7 +1253,7 @@ class ThingsBoardHttpSized
 
       if (!m_client.connected()) {
         if (!m_client.connect(m_host, m_port)) {
-          Logger::log("connect to server failed");
+          Logger::log(PSTR("connect to server failed"));
           return false;
         }
       }
@@ -1275,7 +1274,7 @@ class ThingsBoardHttpSized
     // Sends array of attributes or telemetry to ThingsBoard
     inline const bool sendDataArray(const Telemetry *data, size_t data_count, bool telemetry = true) {
       if (MaxFieldsAmt < data_count) {
-        Logger::log("too much JSON fields passed");
+        Logger::log(PSTR("too much JSON fields passed"));
         return false;
       }
       char payload[PayloadSize];
@@ -1285,13 +1284,13 @@ class ThingsBoardHttpSized
 
         for (size_t i = 0; i < data_count; ++i) {
           if (data[i].serializeKeyval(object) == false) {
-            Logger::log("unable to serialize data");
+            Logger::log(PSTR("unable to serialize data"));
             return false;
           }
         }
 
         if (JSON_STRING_SIZE(measureJson(jsonBuffer)) > PayloadSize) {
-          Logger::log("too small buffer for JSON data");
+          Logger::log(PSTR("too small buffer for JSON data"));
           return false;
         }
         serializeJson(object, payload, sizeof(payload));
@@ -1311,12 +1310,12 @@ class ThingsBoardHttpSized
         StaticJsonDocument<JSON_OBJECT_SIZE(1)> jsonBuffer;
         JsonVariant object = jsonBuffer.template to<JsonVariant>();
         if (t.serializeKeyval(object) == false) {
-          Logger::log("unable to serialize data");
+          Logger::log(PSTR("unable to serialize data"));
           return false;
         }
 
         if (JSON_STRING_SIZE(measureJson(jsonBuffer)) > PayloadSize) {
-          Logger::log("too small buffer for JSON data");
+          Logger::log(PSTR("too small buffer for JSON data"));
           return false;
         }
         serializeJson(object, payload, sizeof(payload));

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -347,6 +347,16 @@ class ThingsBoardSized
       return m_client.publish("v1/devices/me/telemetry", json);
     }
 
+    // Sends custom JSON telemetry JsonObject to the ThingsBoard.
+    inline bool sendTelemetryJson(const JsonObject& jsonObject) {
+      // Serialize the given jsonObject into a char[].
+      // Measure size returns the actual size without null terminator, therefore we add 1.
+      uint32_t json_size = measureJson(jsonObject) + 1U;
+      char json[json_size];
+      serializeJson(jsonObject, json, json_size);
+      return m_client.publish("v1/devices/me/telemetry", json);
+    }
+
     //----------------------------------------------------------------------------
     // Attribute API
 
@@ -383,6 +393,16 @@ class ThingsBoardSized
 
     // Sends custom JSON with attributes to the ThingsBoard.
     inline bool sendAttributeJSON(const char *json) {
+      return m_client.publish("v1/devices/me/attributes", json);
+    }
+
+    // Sends custom JsonObject with attributes to the ThingsBoard.
+    inline bool sendAttributeJSON(const JsonObject& jsonObject) {
+      // Serialize the given jsonObject into a char[].
+      // Measure size returns the actual size without null terminator, therefore we add 1.
+      uint32_t json_size = measureJson(jsonObject) + 1U;
+      char json[json_size];
+      serializeJson(jsonObject, json, json_size);
       return m_client.publish("v1/devices/me/attributes", json);
     }
 

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -215,7 +215,7 @@ class ThingsBoardSized
     // Certain private members can not be set in the constructor initalizor list,
     // because using 2 instances of the ThingsBoard class (for example. provision and connected client)
     // will result in the variables being reset between method calls. Resulting in unexpected behaviour.
-    inline ThingsBoardSized(Client* client)
+    inline ThingsBoardSized(Client& client)
       : m_client()
       , m_requestId(0)
     {
@@ -242,16 +242,11 @@ class ThingsBoardSized
     }
 
     // Sets the underlying Client of the PubSubClient.
-    inline const bool setClient(Client* client) {
-      bool success = false;
-      if (client == nullptr) {
-        return success;
-      }
-      m_client.setClient(*client);
-      success = m_client.setBufferSize(PayloadSize);
+    inline void setClient(Client& client) {
+      m_client.setClient(client);
+      m_client.setBufferSize(PayloadSize);
       // Initalize callback.
       m_client.setCallback(std::bind(&ThingsBoardSized::on_message, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-      return success;
     }
 
     // Connects to the specified ThingsBoard server and port.

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -544,7 +544,7 @@ class ThingsBoardSized
       char buffer[objectSize];
       serializeJson(currentFirmwareInfoObject, buffer, objectSize);
 
-      return sendTelemetryJson(buffer);
+      return sendAttributeJson(buffer);
     }
 
     bool Firmware_Send_State(const char* currFwState) {
@@ -558,7 +558,7 @@ class ThingsBoardSized
       char buffer[objectSize];
       serializeJson(currentFirmwareStateObject, buffer, objectSize);
 
-      return sendTelemetryJson(buffer);
+      return sendAttributeJson(buffer);
     }
 
     bool Firmware_OTA_Subscribe() {

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -188,10 +188,10 @@ class ThingsBoardSized
       : m_client(client)
       , m_requestId(0)
       , m_fwVersion("")
+      , m_fwState("")
       , m_fwTitle("")
       , m_fwChecksum("")
       , m_fwChecksumAlgorithm("")
-      , m_fwState("")
       , m_fwSize(0)
       , m_fwChunkReceive(-1)
     {
@@ -830,7 +830,6 @@ class ThingsBoardSized
 #endif
 
     // Processes shared attribute update message
-
     void process_shared_attribute_update_message(char* topic, uint8_t* payload, unsigned int length) {
       StaticJsonDocument<JSON_OBJECT_SIZE(MaxFieldsAmt)> jsonBuffer;
       DeserializationError error = deserializeJson(jsonBuffer, payload, length);
@@ -946,10 +945,10 @@ class ThingsBoardSized
 #if defined(ESP8266) || defined(ESP32)
     // For Firmware Update
     String m_fwVersion;
+    String m_fwState;
     String m_fwTitle;
     String m_fwChecksum;
     String m_fwChecksumAlgorithm;
-    String m_fwState;
     unsigned int m_fwSize;
     int m_fwChunkReceive;
 #endif

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -414,15 +414,6 @@ class ThingsBoardSized
       if (!host) {
         return false;
       }
-      this->RPC_Unsubscribe(); // Cleanup all RPC subscriptions
-      this->Shared_Attributes_Unsubscribe(); // Cleanup all shared attributes subscriptions
-      this->Shared_Attributes_Request_Unsubscribe(); // Cleanup all shared attributes requests
-#if defined(ESP8266) || defined(ESP32) || defined(ARDUINO_AVR_MEGA)
-      this->Provision_Unsubscribe();
-#endif
-#if defined(ESP8266) || defined(ESP32)
-      this->Firmware_OTA_Unsubscribe();
-#endif
       m_client.setServer(host, port);
       const bool connection_result = m_client.connect(client_id, access_token, password);
       if (!connection_result) {
@@ -433,6 +424,15 @@ class ThingsBoardSized
 
     // Disconnects from ThingsBoard.
     inline void disconnect() {
+      this->RPC_Unsubscribe(); // Cleanup all RPC subscriptions
+      this->Shared_Attributes_Unsubscribe(); // Cleanup all shared attributes subscriptions
+      this->Shared_Attributes_Request_Unsubscribe(); // Cleanup all shared attributes requests
+#if defined(ESP8266) || defined(ESP32) || defined(ARDUINO_AVR_MEGA)
+      this->Provision_Unsubscribe();
+#endif
+#if defined(ESP8266) || defined(ESP32)
+      this->Firmware_OTA_Unsubscribe();
+#endif
       m_client.disconnect();
     }
 

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -367,7 +367,7 @@ class ThingsBoardSized
     // Certain private members can not be set in the constructor initalizor list,
     // because using 2 instances of the ThingsBoard class (for example. provision and connected client)
     // will result in the variables being reset between method calls. Resulting in unexpected behaviour.
-    inline ThingsBoardSized(Client& client, const bool& enableQoS)
+    inline ThingsBoardSized(Client& client, const bool& enableQoS = false)
       : m_client()
       , m_requestId(0)
       , m_qos(enableQoS)
@@ -395,6 +395,8 @@ class ThingsBoardSized
       return m_client;
     }
 
+    // Enables mqtt quality of service for the given underlying MQTT connection.
+    // See https://assetwolf.com/learn/mqtt-qos-understanding-quality-of-service for more information, on quality of service.
     inline void enableMQTTQoS(const bool& enableQoS) {
       m_qos = enableQoS;
     }

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -1070,8 +1070,14 @@ class ThingsBoardSized
           StaticJsonDocument<JSON_OBJECT_SIZE(MaxFieldsAmt)> doc;
           DeserializationError err_param = deserializeJson(doc, params);
           //if failed to de-serialize params then send JsonObject instead
+          Logger::log(RPC_PARAMS_KEY);
           if (err_param) {
-            r = callback.m_cb(data[RPC_PARAMS_KEY]);
+            const JsonVariant &param = data[RPC_PARAMS_KEY].as<JsonVariant>();
+            const uint32_t json_size = JSON_STRING_SIZE(measureJson(param));
+            char json[json_size];
+            serializeJson(param, json, json_size);
+          	Logger::log(json);
+            r = callback.m_cb(param);
           } else {
             Logger::log(params);
             const JsonObject &param = doc.template as<JsonObject>();

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -99,11 +99,12 @@ class Telemetry {
 
 using Attribute = Telemetry;
 using RPC_Response = Telemetry;
-// JSON object is used to communicate RPC parameters to the client
-using RPC_Data = JsonVariant;
-using Shared_Attribute_Data = JsonObject;
+// JSON variant const (read only twice as small as JSON variant), is used to communicate RPC parameters to the client
+using RPC_Data = JsonVariantConst;
+// JSON object const (read only twice as small as JSON object), is used to communicate Shared Attributes and Provision Data to the client
+using Shared_Attribute_Data = JsonObjectConst;
 #if defined(ESP8266) || defined(ESP32) || defined(ARDUINO_AVR_MEGA)
-using Provision_Data = JsonObject;
+using Provision_Data = JsonObjectConst;
 #endif
 
 // RPC callback wrapper

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -19,6 +19,7 @@
 
 #include <PubSubClient.h>
 #include <ArduinoJson.h>
+#include <vector>
 
 // Local includes.
 #include "ThingsBoardDefaultLogger.h"

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -991,7 +991,7 @@ class ThingsBoardSized
           continue;
         }
 
-        char message[53U + sizeof(requested_att)];
+        char message[53U + strlen(requested_att) + 1U];
         snprintf_P(message, sizeof(message), PSTR("Calling subscribed callback for updated attribute (%s)"), requested_att);
         Logger::log(message);
         // Getting non-existing field from JSON should automatically

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -123,7 +123,7 @@ const char PROV_DEVICE_SECRET_KEY[] = PSTR("provisionDeviceSecret");
 // Provision data keys.
 const char PROV_STATUS_KEY[] = PSTR("status");
 const char PROV_CRED_TYPE_KEY[] = PSTR("credentialsType");
-const char SUCCESS[] = PSTR("SUCCESS");
+const char STATUS_SUCCESS[] = PSTR("SUCCESS");
 const char PROV_CRED_TYPE_VALUE[] = PSTR("X509_CERTIFICATE");
 
 // Log messages.
@@ -840,9 +840,9 @@ class ThingsBoardSized
 
       bool success = false;
       // Update current_fw_title and current_fw_version if updating was a success.
-      if (strncmp_P(SUCCESS, m_fwState, strlen(SUCCESS)) == 0) {
+      if (strncmp_P(STATUS_SUCCESS, m_fwState, strlen(STATUS_SUCCESS)) == 0) {
         Firmware_Send_FW_Info(fw_title, fw_version);
-        Firmware_Send_State(SUCCESS);
+        Firmware_Send_State(STATUS_SUCCESS);
         success = true;
       }
       else {
@@ -1168,7 +1168,7 @@ class ThingsBoardSized
           Logger::log(CHKS_VER_SUCCESS);
           if (Update.end(true)) {
             Logger::log(FW_UPDATE_SUCCESS);
-            m_fwState = SUCCESS;
+            m_fwState = STATUS_SUCCESS;
           }
         }
       }
@@ -1310,7 +1310,7 @@ class ThingsBoardSized
 
       Logger::log(RECEIVED_PROV_RESPONSE);
 
-      if (strncmp_P(SUCCESS, data[PROV_STATUS_KEY], strlen(SUCCESS)) == 0 && strncmp_P(PROV_CRED_TYPE_VALUE, data[PROV_CRED_TYPE_KEY], strlen(PROV_CRED_TYPE_VALUE)) == 0) {
+      if (strncmp_P(STATUS_SUCCESS, data[PROV_STATUS_KEY], strlen(STATUS_SUCCESS)) == 0 && strncmp_P(PROV_CRED_TYPE_VALUE, data[PROV_CRED_TYPE_KEY], strlen(PROV_CRED_TYPE_VALUE)) == 0) {
         Logger::log(X509_NOT_SUPPORTED);
         return;
       }

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -589,6 +589,10 @@ class ThingsBoardSized
 
       std::string sharedKeys = "";
       for (const char* attribute : attributes) {
+        // Check if the given attribute is null, if it is skip it.
+        if (attribute == nullptr) {
+          continue;
+        }
         sharedKeys.append(attribute);
         sharedKeys.append(",");
       }

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -355,7 +355,6 @@ class ThingsBoardSized
       uint32_t json_size = measureJson(jsonObject) + 1U;
       char json[json_size];
       serializeJson(jsonObject, json, json_size);
-      Logger::log(json);
       return m_client.publish("v1/devices/me/telemetry", json);
     }
 

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -416,7 +416,18 @@ class ThingsBoardSized
       }
       m_client.setServer(host, port);
       const bool connection_result = m_client.connect(client_id, access_token, password);
-      if (!connection_result) {
+      if (connection_result) {
+        this->RPC_Unsubscribe(); // Cleanup all RPC subscriptions
+        this->Shared_Attributes_Unsubscribe(); // Cleanup all shared attributes subscriptions
+        this->Shared_Attributes_Request_Unsubscribe(); // Cleanup all shared attributes requests
+#if defined(ESP8266) || defined(ESP32) || defined(ARDUINO_AVR_MEGA)
+        this->Provision_Unsubscribe();
+#endif
+#if defined(ESP8266) || defined(ESP32)
+        this->Firmware_OTA_Unsubscribe();
+#endif
+      }
+      else {
         Logger::log(CONNECT_FAILED);
       }
       return connection_result;
@@ -424,15 +435,6 @@ class ThingsBoardSized
 
     // Disconnects from ThingsBoard.
     inline void disconnect() {
-      this->RPC_Unsubscribe(); // Cleanup all RPC subscriptions
-      this->Shared_Attributes_Unsubscribe(); // Cleanup all shared attributes subscriptions
-      this->Shared_Attributes_Request_Unsubscribe(); // Cleanup all shared attributes requests
-#if defined(ESP8266) || defined(ESP32) || defined(ARDUINO_AVR_MEGA)
-      this->Provision_Unsubscribe();
-#endif
-#if defined(ESP8266) || defined(ESP32)
-      this->Firmware_OTA_Unsubscribe();
-#endif
       m_client.disconnect();
     }
 

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -215,12 +215,12 @@ class ThingsBoardSized
     // Certain private members can not be set in the constructor initalizor list,
     // because using 2 instances of the ThingsBoard class (for example. provision and connected client)
     // will result in the variables being reset between method calls. Resulting in unexpected behaviour.
-    inline ThingsBoardSized(Client& client)
+    inline ThingsBoardSized(Client* client)
       : m_client()
       , m_requestId(0)
     {
       reserve_callback_size();
-      setClient(&client);
+      setClient(client);
     }
 
     // Initializes ThingsBoardSized class without network client. Ensure it is set via. setClient() before using the connect method.
@@ -275,7 +275,7 @@ class ThingsBoardSized
       return connection_result;
     }
 
-    // Disconnects from ThingsBoard. Returns true on success.
+    // Disconnects from ThingsBoard.
     inline void disconnect() {
       m_client.disconnect();
     }

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -544,7 +544,7 @@ class ThingsBoardSized
       char buffer[objectSize];
       serializeJson(currentFirmwareInfoObject, buffer, objectSize);
 
-      return sendAttributeJson(buffer);
+      return sendTelemetryJson(buffer);
     }
 
     bool Firmware_Send_State(const char* currFwState) {
@@ -558,7 +558,7 @@ class ThingsBoardSized
       char buffer[objectSize];
       serializeJson(currentFirmwareStateObject, buffer, objectSize);
 
-      return sendAttributeJson(buffer);
+      return sendTelemetryJson(buffer);
     }
 
     bool Firmware_OTA_Subscribe() {

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -881,7 +881,7 @@ class ThingsBoardSized
 
       m_fwChunkReceive = atoi(strrchr(topic, '/') + 1);
 
-      char message[33U + detect_size(m_fwChunkReceive) + detect_size(length)];
+      char message[37U + detect_size(m_fwChunkReceive) + detect_size(length)];
       snprintf_P(message, sizeof(message), PSTR("Receive chunk (%i), with size (%u) bytes"), m_fwChunkReceive, length);
       Logger::log(message);
 
@@ -915,10 +915,10 @@ class ThingsBoardSized
       if (m_fwSize == sizeReceive) {
         md5.calculate();
         String md5Str = md5.toString();
-        char actual[22U + md5Str.length()];
+        char actual[24U + md5Str.length()];
         snprintf_P(actual, sizeof(actual), PSTR("MD5 actual checksum: (%s)"), md5Str.c_str());
         Logger::log(actual);
-        char expected[24U + m_fwChecksum.length()];
+        char expected[26U + m_fwChecksum.length()];
         snprintf_P(expected, sizeof(expected), PSTR("MD5 expected checksum: (%s)"), m_fwChecksum.c_str());
         Logger::log(expected);
         // Check MD5
@@ -991,7 +991,7 @@ class ThingsBoardSized
           continue;
         }
 
-        char message[51U + sizeof(requested_att)];
+        char message[53U + sizeof(requested_att)];
         snprintf_P(message, sizeof(message), PSTR("Calling subscribed callback for updated attribute (%s)"), requested_att);
         Logger::log(message);
         // Getting non-existing field from JSON should automatically
@@ -1054,7 +1054,7 @@ class ThingsBoardSized
           continue;
         }
 
-        char message[45U + detect_size(response_id)];
+        char message[47U + detect_size(response_id)];
         snprintf_P(message, sizeof(message), PSTR("Calling subscribed callback for response id (%u)"), response_id);
         Logger::log(message);
         // Getting non-existing field from JSON should automatically

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -602,7 +602,7 @@ class ThingsBoardSized
         return false;
       }
 
-      requestObject["sharedKeys"] = sharedKeys;
+      requestObject["sharedKeys"] = sharedKeys.c_str();
       int objectSize = measureJson(requestBuffer) + 1;
       char buffer[objectSize];
       serializeJson(requestObject, buffer, objectSize);

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -33,150 +33,150 @@ class ThingsBoardDefaultLogger;
 /// Constant strings in flash memory.
 /// ---------------------------------
 #if !defined(ESP8266) && !defined(ESP32)
-const char HTTP_TELEMETRY_TOPIC[] = PSTR("/api/v1/%s/telemetry");
-const char HTTP_ATTRIBUTES_TOPIC[] = PSTR("/api/v1/%s/attributes");
-const char HTTP_POST_PATH[] = PSTR("application/json");
+constexpr char HTTP_TELEMETRY_TOPIC[] = PSTR("/api/v1/%s/telemetry");
+constexpr char HTTP_ATTRIBUTES_TOPIC[] = PSTR("/api/v1/%s/attributes");
+constexpr char HTTP_POST_PATH[] = PSTR("application/json");
 #endif
 
 // Publish data topics.
-const char ATTRIBUTE_TOPIC[] = PSTR("v1/devices/me/attributes");
-const char TELEMETRY_TOPIC[] = PSTR("v1/devices/me/telemetry");
+constexpr char ATTRIBUTE_TOPIC[] = PSTR("v1/devices/me/attributes");
+constexpr char TELEMETRY_TOPIC[] = PSTR("v1/devices/me/telemetry");
 
 // RPC topics.
-const char RPC_SUBSCRIBE_TOPIC[] = PSTR("v1/devices/me/rpc/request/+");
-const char RPC_TOPIC[] = PSTR("v1/devices/me/rpc");
+constexpr char RPC_SUBSCRIBE_TOPIC[] = PSTR("v1/devices/me/rpc/request/+");
+constexpr char RPC_TOPIC[] = PSTR("v1/devices/me/rpc");
 
 // Firmware topics.
-const char FIRMWARE_RESPONSE_TOPIC[] = PSTR("v2/fw/response");
+constexpr char FIRMWARE_RESPONSE_TOPIC[] = PSTR("v2/fw/response");
 
 // Shared attribute topics.
-const char ATTRIBUTE_REQUEST_TOPIC[] = PSTR("v1/devices/me/attributes/request/%u");
-const char ATTRIBUTE_RESPONSE_SUBSCRIBE_TOPIC[] = PSTR("v1/devices/me/attributes/response/+");
-const char ATTRIBUTE_RESPONSE_TOPIC[] = PSTR("v1/devices/me/attributes/response");
+constexpr char ATTRIBUTE_REQUEST_TOPIC[] = PSTR("v1/devices/me/attributes/request/%u");
+constexpr char ATTRIBUTE_RESPONSE_SUBSCRIBE_TOPIC[] = PSTR("v1/devices/me/attributes/response/+");
+constexpr char ATTRIBUTE_RESPONSE_TOPIC[] = PSTR("v1/devices/me/attributes/response");
 
 // Provision topics.
-const char PROV_RESPONSE_TOPIC[] = PSTR("/provision/response");
+constexpr char PROV_RESPONSE_TOPIC[] = PSTR("/provision/response");
 
 // Default login data.
-const char PROV_ACCESS_TOKEN[] = PSTR("provision");
-const char DEFAULT_CLIENT_ID[] = PSTR("TbDev");
+constexpr char PROV_ACCESS_TOKEN[] = PSTR("provision");
+constexpr char DEFAULT_CLIENT_ID[] = PSTR("TbDev");
 
 // Shared attribute request keys.
-const char SHARED_KEYS[] = PSTR("sharedKeys");
-const char SHARED_KEY[] = PSTR("shared");
+constexpr char SHARED_KEYS[] = PSTR("sharedKeys");
+constexpr char SHARED_KEY[] = PSTR("shared");
 
 // RPC data keys.
-const char RPC_METHOD_KEY[] = PSTR("method");
-const char RPC_PARAMS_KEY[] = PSTR("params");
-const char RPC_REQUEST_KEY[] = PSTR("request");
-const char RPC_RESPONSE_KEY[] = PSTR("response");
+constexpr char RPC_METHOD_KEY[] = PSTR("method");
+constexpr char RPC_PARAMS_KEY[] = PSTR("params");
+constexpr char RPC_REQUEST_KEY[] = PSTR("request");
+constexpr char RPC_RESPONSE_KEY[] = PSTR("response");
 
 // Log messages.
-const char INVALID_BUFFER_SIZE[] = PSTR("PayloadSize (%u) to small for the given payloads size (%u)");
-const char MAX_RPC_EXCEEDED[] = PSTR("Too many rpc subscriptions, increase MaxFieldsAmt or unsubscribe");
-const char MAX_SHARED_ATT_UPDATE_EXCEEDED[] = PSTR("Too many shared attribute update callback subscriptions, increase MaxFieldsAmt or unsubscribe");
-const char MAX_SHARED_ATT_REQUEST_EXCEEDED[] = PSTR("Too many shared attribute request callback subscriptions, increase MaxFieldsAmt");
-const char NUMBER_PRINTF[] = PSTR("%u");
-const char COMMA = PSTR(',');
-const char NO_KEYS_TO_REQUEST[] = PSTR("No keys to request were given");
-const char REQUEST_ATT[] = PSTR("Requesting shared attributes transformed from (%s) into json (%s)");
-const char UNABLE_TO_SERIALIZE[] = PSTR("Unable to serialize data");
-const char UNABLE_TO_DE_SERIALIZE_RPC[] = PSTR("Unable to de-serialize RPC");
-const char UNABLE_TO_DE_SERIALIZE_ATT_REQUEST[] = PSTR("Unable to de-serialize shared attribute request");
-const char UNABLE_TO_DE_SERIALIZE_ATT_UPDATE[] = PSTR("Unable to de-serialize shared attribute update");
-const char RECEIVED_RPC_LOG_MESSAGE[] = PSTR("Received RPC:");
-const char RPC_METHOD_NULL[] = PSTR("RPC method is NULL");
-const char RPC_CB_NULL[] = PSTR("RPC callback or subscribed rpc method name is NULL");
-const char NO_RPC_PARAMS_PASSED[] = PSTR("No parameters passed with RPC, passing null JSON");
-const char CALLING_RPC[] = PSTR("Calling RPC:");
-const char RECEIVED_ATT_UPDATE[] = PSTR("Received shared attribute update");
-const char NOT_FOUND_ATT_UPDATE[] = PSTR("Shared attribute update key not found");
-const char ATT_CB_ID[] = PSTR("Shared attribute update callback id: (%u)");
-const char ATT_CB_IS_NULL[] = PSTR("Shared attribute update callback is NULL");
-const char ATT_CB_NO_KEYS[] = PSTR("No keys subscribed. Calling subscribed callback for any updated attributes (assumed to be subscribed to every possible key)");
-const char ATT_IS_NULL[] = PSTR("Subscribed shared attribute update key is NULL");
-const char ATT_IN_ARRAY[] = PSTR("Shared attribute update key: (%s) is subscribed");
-const char ATT_NO_CHANGE[] = PSTR("No keys that we subscribed too were changed, skipping callback");
-const char CALLING_ATT_CB[] = PSTR("Calling subscribed callback for updated shared attribute (%s)");
-const char RECEIVED_ATT[] = PSTR("Received shared attribute request");
-const char ATT_KEY_NOT_FOUND[] = PSTR("Shared attribute key not found");
-const char ATT_REQUEST_CB_IS_NULL[] = PSTR("Shared attribute request callback is NULL");
-const char CALLING_REQUEST_ATT_CB[] = PSTR("Calling subscribed callback for response id (%u)");
-const char TOO_MANY_JSON_FIELDS[] = PSTR("Too many JSON fields passed (%u), increase MaxFieldsAmt (%u) accordingly");
-const char CB_ON_MESSAGE[] = PSTR("Callback on_message from topic: (%s)");
-const char CONNECT_FAILED[] = PSTR("Connecting to server failed");
+constexpr char INVALID_BUFFER_SIZE[] = PSTR("PayloadSize (%u) to small for the given payloads size (%u)");
+constexpr char MAX_RPC_EXCEEDED[] = PSTR("Too many rpc subscriptions, increase MaxFieldsAmt or unsubscribe");
+constexpr char MAX_SHARED_ATT_UPDATE_EXCEEDED[] = PSTR("Too many shared attribute update callback subscriptions, increase MaxFieldsAmt or unsubscribe");
+constexpr char MAX_SHARED_ATT_REQUEST_EXCEEDED[] = PSTR("Too many shared attribute request callback subscriptions, increase MaxFieldsAmt");
+constexpr char NUMBER_PRINTF[] = PSTR("%u");
+constexpr char COMMA = PSTR(',');
+constexpr char NO_KEYS_TO_REQUEST[] = PSTR("No keys to request were given");
+constexpr char REQUEST_ATT[] = PSTR("Requesting shared attributes transformed from (%s) into json (%s)");
+constexpr char UNABLE_TO_SERIALIZE[] = PSTR("Unable to serialize data");
+constexpr char UNABLE_TO_DE_SERIALIZE_RPC[] = PSTR("Unable to de-serialize RPC");
+constexpr char UNABLE_TO_DE_SERIALIZE_ATT_REQUEST[] = PSTR("Unable to de-serialize shared attribute request");
+constexpr char UNABLE_TO_DE_SERIALIZE_ATT_UPDATE[] = PSTR("Unable to de-serialize shared attribute update");
+constexpr char RECEIVED_RPC_LOG_MESSAGE[] = PSTR("Received RPC:");
+constexpr char RPC_METHOD_NULL[] = PSTR("RPC method is NULL");
+constexpr char RPC_CB_NULL[] = PSTR("RPC callback or subscribed rpc method name is NULL");
+constexpr char NO_RPC_PARAMS_PASSED[] = PSTR("No parameters passed with RPC, passing null JSON");
+constexpr char CALLING_RPC[] = PSTR("Calling RPC:");
+constexpr char RECEIVED_ATT_UPDATE[] = PSTR("Received shared attribute update");
+constexpr char NOT_FOUND_ATT_UPDATE[] = PSTR("Shared attribute update key not found");
+constexpr char ATT_CB_ID[] = PSTR("Shared attribute update callback id: (%u)");
+constexpr char ATT_CB_IS_NULL[] = PSTR("Shared attribute update callback is NULL");
+constexpr char ATT_CB_NO_KEYS[] = PSTR("No keys subscribed. Calling subscribed callback for any updated attributes (assumed to be subscribed to every possible key)");
+constexpr char ATT_IS_NULL[] = PSTR("Subscribed shared attribute update key is NULL");
+constexpr char ATT_IN_ARRAY[] = PSTR("Shared attribute update key: (%s) is subscribed");
+constexpr char ATT_NO_CHANGE[] = PSTR("No keys that we subscribed too were changed, skipping callback");
+constexpr char CALLING_ATT_CB[] = PSTR("Calling subscribed callback for updated shared attribute (%s)");
+constexpr char RECEIVED_ATT[] = PSTR("Received shared attribute request");
+constexpr char ATT_KEY_NOT_FOUND[] = PSTR("Shared attribute key not found");
+constexpr char ATT_REQUEST_CB_IS_NULL[] = PSTR("Shared attribute request callback is NULL");
+constexpr char CALLING_REQUEST_ATT_CB[] = PSTR("Calling subscribed callback for response id (%u)");
+constexpr char TOO_MANY_JSON_FIELDS[] = PSTR("Too many JSON fields passed (%u), increase MaxFieldsAmt (%u) accordingly");
+constexpr char CB_ON_MESSAGE[] = PSTR("Callback on_message from topic: (%s)");
+constexpr char CONNECT_FAILED[] = PSTR("Connecting to server failed");
 
 #if defined(ESP8266) || defined(ESP32) || defined(ARDUINO_AVR_MEGA)
 // Claim topics.
-const char CLAIM_TOPIC[] = PSTR("v1/devices/me/claim");
+constexpr char CLAIM_TOPIC[] = PSTR("v1/devices/me/claim");
 
 // Provision topics.
-const char PROV_REQUEST_TOPIC[] = PSTR("/provision/request");
+constexpr char PROV_REQUEST_TOPIC[] = PSTR("/provision/request");
 
 // Claim data keys.
-const char SECRET_KEY[] = PSTR("secretKey");
-const char DURATION_KEY[] = PSTR("durationMs");
-const char DEVICE_NAME_KEY[] = PSTR("deviceName");
-const char PROV_DEVICE_KEY[] = PSTR("provisionDeviceKey");
-const char PROV_DEVICE_SECRET_KEY[] = PSTR("provisionDeviceSecret");
+constexpr char SECRET_KEY[] = PSTR("secretKey");
+constexpr char DURATION_KEY[] = PSTR("durationMs");
+constexpr char DEVICE_NAME_KEY[] = PSTR("deviceName");
+constexpr char PROV_DEVICE_KEY[] = PSTR("provisionDeviceKey");
+constexpr char PROV_DEVICE_SECRET_KEY[] = PSTR("provisionDeviceSecret");
 
 // Provision data keys.
-const char PROV_STATUS_KEY[] = PSTR("status");
-const char PROV_CRED_TYPE_KEY[] = PSTR("credentialsType");
-const char STATUS_SUCCESS[] = PSTR("SUCCESS");
-const char PROV_CRED_TYPE_VALUE[] = PSTR("X509_CERTIFICATE");
+constexpr char PROV_STATUS_KEY[] = PSTR("status");
+constexpr char PROV_CRED_TYPE_KEY[] = PSTR("credentialsType");
+constexpr char STATUS_SUCCESS[] = PSTR("SUCCESS");
+constexpr char PROV_CRED_TYPE_VALUE[] = PSTR("X509_CERTIFICATE");
 
 // Log messages.
-const char PROV_REQUEST[] = PSTR("Provision request:");
-const char UNABLE_TO_DE_SERIALIZE_PROV_RESPONSE[] = PSTR("Unable to de-serialize provision response");
-const char PROV_RESPONSE[] = PSTR("Process provisioning response");
-const char RECEIVED_PROV_RESPONSE[] = PSTR("Received provision response");
-const char X509_NOT_SUPPORTED[] = PSTR("Provision response contains X509_CERTIFICATE credentials, this is not supported yet");
+constexpr char PROV_REQUEST[] = PSTR("Provision request:");
+constexpr char UNABLE_TO_DE_SERIALIZE_PROV_RESPONSE[] = PSTR("Unable to de-serialize provision response");
+constexpr char PROV_RESPONSE[] = PSTR("Process provisioning response");
+constexpr char RECEIVED_PROV_RESPONSE[] = PSTR("Received provision response");
+constexpr char X509_NOT_SUPPORTED[] = PSTR("Provision response contains X509_CERTIFICATE credentials, this is not supported yet");
 
 #if !defined(ARDUINO_AVR_MEGA)
 // Firmware topics.
-const char FIRMWARE_RESPONSE_SUBSCRIBE_TOPIC[] = PSTR("v2/fw/response/#");
-const char FIRMWARE_REQUEST_TOPIC[] = PSTR("v2/fw/request/0/chunk/%u");
+constexpr char FIRMWARE_RESPONSE_SUBSCRIBE_TOPIC[] = PSTR("v2/fw/response/#");
+constexpr char FIRMWARE_REQUEST_TOPIC[] = PSTR("v2/fw/request/0/chunk/%u");
 
 // Firmware data keys.
-const char CURR_FW_TITLE_KEY[] = PSTR("current_fw_title");
-const char CURR_FW_VER_KEY[] = PSTR("current_fw_version");
-const char CURR_FW_STATE_KEY[] = PSTR("current_fw_state");
-const char FW_VER_KEY[] = PSTR("fw_version");
-const char FW_TITLE_KEY[] = PSTR("fw_title");
-const char FW_CHKS_KEY[] = PSTR("fw_checksum");
-const char FW_CHKS_ALGO_KEY[] = PSTR("fw_checksum_algorithm");
-const char FW_SIZE_KEY[] = PSTR("fw_size");
-const char FW_CHECKSUM_VALUE[] = PSTR("MD5");
-const char FW_STATE_CHECKING[] = PSTR("CHECKING FIRMWARE");
-const char FW_STATE_NO_FW[] = PSTR("NO FIRMWARE FOUND");
-const char FW_STATE_UP_TO_DATE[] = PSTR("UP TO DATE");
-const char FW_STATE_INVALID_CHKS[] = PSTR("CHKS IS NOT MD5");
-const char FW_STATE_DOWNLOADING[] = PSTR("DOWNLOADING");
-const char FW_STATE_FAILED[] = PSTR("FAILED");
-const char FW_STATE_UPDATE_ERROR[] = PSTR("UPDATE ERROR");
-const char FW_STATE_CHKS_ERROR[] = PSTR("CHECKSUM ERROR");
+constexpr char CURR_FW_TITLE_KEY[] = PSTR("current_fw_title");
+constexpr char CURR_FW_VER_KEY[] = PSTR("current_fw_version");
+constexpr char CURR_FW_STATE_KEY[] = PSTR("current_fw_state");
+constexpr char FW_VER_KEY[] = PSTR("fw_version");
+constexpr char FW_TITLE_KEY[] = PSTR("fw_title");
+constexpr char FW_CHKS_KEY[] = PSTR("fw_checksum");
+constexpr char FW_CHKS_ALGO_KEY[] = PSTR("fw_checksum_algorithm");
+constexpr char FW_SIZE_KEY[] = PSTR("fw_size");
+constexpr char FW_CHECKSUM_VALUE[] = PSTR("MD5");
+constexpr char FW_STATE_CHECKING[] = PSTR("CHECKING FIRMWARE");
+constexpr char FW_STATE_NO_FW[] = PSTR("NO FIRMWARE FOUND");
+constexpr char FW_STATE_UP_TO_DATE[] = PSTR("UP TO DATE");
+constexpr char FW_STATE_INVALID_CHKS[] = PSTR("CHKS IS NOT MD5");
+constexpr char FW_STATE_DOWNLOADING[] = PSTR("DOWNLOADING");
+constexpr char FW_STATE_FAILED[] = PSTR("FAILED");
+constexpr char FW_STATE_UPDATE_ERROR[] = PSTR("UPDATE ERROR");
+constexpr char FW_STATE_CHKS_ERROR[] = PSTR("CHECKSUM ERROR");
 
 // Log messages.
-const char NO_FW[] = PSTR("No new firmware assigned on the given device");
-const char FW_UP_TO_DATE[] = PSTR("Firmware is already up to date");
-const char FW_NOT_FOR_US[] = PSTR("Firmware is not for us (title is different)");
-const char FW_CHKS_ALGO_NOT_SUPPORTED[] = PSTR("Checksum algorithm is not supported, please use MD5 only");
-const char PAGE_BREAK[] = PSTR("=================================");
-const char NEW_FW[] = PSTR("A new Firmware is available:");
-const char FROM_TOO[] = PSTR("(%s) => (%s)");
-const char DOWNLOADING_FW[] = PSTR("Attempting to download over MQTT...");
-const char NOT_ENOUGH_RAM[] = PSTR("Not enough RAM");
-const char SLASH = PSTR('/');
-const char UNABLE_TO_WRITE[] = PSTR("Unable to write firmware");
-const char UNABLE_TO_DOWNLOAD[] = PSTR("Unable to download firmware");
-const char FW_CHUNK[] = PSTR("Receive chunk (%i), with size (%u) bytes");
-const char ERROR_UPDATE_BEGIN[] = PSTR("Error during Update.begin");
-const char MD5_ACTUAL[] = PSTR("MD5 actual checksum: (%s)");
-const char MD5_EXPECTED[] = PSTR("MD5 expected checksum: (%s)");
-const char CHKS_VER_FAILED[] = PSTR("Checksum verification failed");
-const char CHKS_VER_SUCCESS[] = PSTR("Checksum is the same as expected");
-const char FW_UPDATE_SUCCESS[] = PSTR("Update success");
+constexpr char NO_FW[] = PSTR("No new firmware assigned on the given device");
+constexpr char FW_UP_TO_DATE[] = PSTR("Firmware is already up to date");
+constexpr char FW_NOT_FOR_US[] = PSTR("Firmware is not for us (title is different)");
+constexpr char FW_CHKS_ALGO_NOT_SUPPORTED[] = PSTR("Checksum algorithm is not supported, please use MD5 only");
+constexpr char PAGE_BREAK[] = PSTR("=================================");
+constexpr char NEW_FW[] = PSTR("A new Firmware is available:");
+constexpr char FROM_TOO[] = PSTR("(%s) => (%s)");
+constexpr char DOWNLOADING_FW[] = PSTR("Attempting to download over MQTT...");
+constexpr char NOT_ENOUGH_RAM[] = PSTR("Not enough RAM");
+constexpr char SLASH = PSTR('/');
+constexpr char UNABLE_TO_WRITE[] = PSTR("Unable to write firmware");
+constexpr char UNABLE_TO_DOWNLOAD[] = PSTR("Unable to download firmware");
+constexpr char FW_CHUNK[] = PSTR("Receive chunk (%i), with size (%u) bytes");
+constexpr char ERROR_UPDATE_BEGIN[] = PSTR("Error during Update.begin");
+constexpr char MD5_ACTUAL[] = PSTR("MD5 actual checksum: (%s)");
+constexpr char MD5_EXPECTED[] = PSTR("MD5 expected checksum: (%s)");
+constexpr char CHKS_VER_FAILED[] = PSTR("Checksum verification failed");
+constexpr char CHKS_VER_SUCCESS[] = PSTR("Checksum is the same as expected");
+constexpr char FW_UPDATE_SUCCESS[] = PSTR("Update success");
 #endif
 #endif
 

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -256,8 +256,8 @@ class ThingsBoardSized
       StaticJsonDocument<JSON_OBJECT_SIZE(1)> requestBuffer;
       JsonObject resp_obj = requestBuffer.to<JsonObject>();
 
-      resp_obj["secretKey"] = secretKey;
-      resp_obj["durationMs"] = durationMs;
+      resp_obj[F("secretKey")] = secretKey;
+      resp_obj[F("durationMs")] = durationMs;
 
       uint8_t objectSize = measureJson(requestBuffer) + 1;
       char responsePayload[objectSize];
@@ -272,9 +272,9 @@ class ThingsBoardSized
       StaticJsonDocument<JSON_OBJECT_SIZE(3)> requestBuffer;
       JsonObject requestObject = requestBuffer.to<JsonObject>();
 
-      requestObject["deviceName"] = deviceName;
-      requestObject["provisionDeviceKey"] = provisionDeviceKey;
-      requestObject["provisionDeviceSecret"] = provisionDeviceSecret;
+      requestObject[F("deviceName")] = deviceName;
+      requestObject[F("provisionDeviceKey")] = provisionDeviceKey;
+      requestObject[F("provisionDeviceSecret")] = provisionDeviceSecret;
 
       uint8_t objectSize = measureJson(requestBuffer) + 1;
       char requestPayload[objectSize];
@@ -540,8 +540,8 @@ class ThingsBoardSized
       StaticJsonDocument<JSON_OBJECT_SIZE(2)> currentFirmwareInfo;
       JsonObject currentFirmwareInfoObject = currentFirmwareInfo.to<JsonObject>();
 
-      currentFirmwareInfoObject["current_fw_title"] = currFwTitle;
-      currentFirmwareInfoObject["current_fw_version"] = currFwVersion;
+      currentFirmwareInfoObject[F("current_fw_title")] = currFwTitle;
+      currentFirmwareInfoObject[F("current_fw_version")] = currFwVersion;
 
       int objectSize = measureJson(currentFirmwareInfo) + 1;
       char buffer[objectSize];
@@ -555,7 +555,7 @@ class ThingsBoardSized
       StaticJsonDocument<JSON_OBJECT_SIZE(1)> currentFirmwareState;
       JsonObject currentFirmwareStateObject = currentFirmwareState.to<JsonObject>();
 
-      currentFirmwareStateObject["current_fw_state"] = currFwState;
+      currentFirmwareStateObject[F("current_fw_state")] = currFwState;
 
       int objectSize = measureJson(currentFirmwareState) + 1;
       char buffer[objectSize];
@@ -603,7 +603,7 @@ class ThingsBoardSized
         return false;
       }
 
-      requestObject["sharedKeys"] = sharedKeys.c_str();
+      requestObject[F("sharedKeys")] = sharedKeys.c_str();
       int objectSize = measureJson(requestBuffer) + 1;
       char buffer[objectSize];
       serializeJson(requestObject, buffer, objectSize);
@@ -719,8 +719,8 @@ class ThingsBoardSized
           return;
         }
         const JsonObject &data = jsonBuffer.template as<JsonObject>();
-        const char *methodName = data["method"];
-        const char *params = data["params"];
+        const char *methodName = data[F("method")];
+        const char *params = data[F("params")];
 
         if (methodName) {
           Logger::log("received RPC:");
@@ -750,8 +750,8 @@ class ThingsBoardSized
           //if failed to de-serialize params then send JsonObject instead
           if (err_param) {
             Logger::log("params:");
-            Logger::log(data["params"].as<String>().c_str());
-            r = callback.m_cb(data["params"]);
+            Logger::log(data[F("params")].as<String>().c_str());
+            r = callback.m_cb(data[F("params")]);
           } else {
             Logger::log("params:");
             Logger::log(params);
@@ -859,8 +859,8 @@ class ThingsBoardSized
 
       if (data && (data.size() >= 1)) {
         Logger::log("Received shared attribute update request");
-        if (data["shared"]) {
-          data = data["shared"];
+        if (data[F("shared")]) {
+          data = data[F("shared")];
         }
       } else {
         Logger::log("Shared attribute update key not found.");
@@ -869,20 +869,20 @@ class ThingsBoardSized
 
       // Save data for firmware update
 #if defined(ESP8266) || defined(ESP32)
-      if (data["fw_title"]) {
-        m_fwTitle = data["fw_title"].as<String>();
+      if (data[F("fw_title")]) {
+        m_fwTitle = data[F("fw_title")].as<String>();
       }
-      if (data["fw_version"]) {
-        m_fwVersion = data["fw_version"].as<String>();
+      if (data[F("fw_version")]) {
+        m_fwVersion = data[F("fw_version")].as<String>();
       }
-      if (data["fw_checksum"]) {
-        m_fwChecksum = data["fw_checksum"].as<String>();
+      if (data[F("fw_checksum")]) {
+        m_fwChecksum = data[F("fw_checksum")].as<String>();
       }
-      if (data["fw_checksum_algorithm"]) {
-        m_fwChecksumAlgorithm = data["fw_checksum_algorithm"].as<String>();
+      if (data[F("fw_checksum_algorithm")]) {
+        m_fwChecksumAlgorithm = data[F("fw_checksum_algorithm")].as<String>();
       }
-      if (data["fw_size"]) {
-        m_fwSize = data["fw_size"].as<int>();
+      if (data[F("fw_size")]) {
+        m_fwSize = data[F("fw_size")].as<int>();
       }
 #endif
 
@@ -920,7 +920,7 @@ class ThingsBoardSized
 
       Logger::log("Received provision response");
 
-      if (data["status"] == "SUCCESS" && data["credentialsType"] == "X509_CERTIFICATE") {
+      if (data[F("status")] == "SUCCESS" && data[F("credentialsType")] == "X509_CERTIFICATE") {
         Logger::log("Provision response contains X509_CERTIFICATE credentials, it is not supported yet.");
         return;
       }

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -1070,9 +1070,7 @@ class ThingsBoardSized
           StaticJsonDocument<JSON_OBJECT_SIZE(MaxFieldsAmt)> doc;
           DeserializationError err_param = deserializeJson(doc, params);
           //if failed to de-serialize params then send JsonObject instead
-          Logger::log(RPC_PARAMS_KEY);
           if (err_param) {
-            Logger::log(data[RPC_PARAMS_KEY].as<const char*>());
             r = callback.m_cb(data[RPC_PARAMS_KEY]);
           } else {
             Logger::log(params);

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -28,6 +28,157 @@
 
 class ThingsBoardDefaultLogger;
 
+/// ---------------------------------
+/// Constant strings in flash memory.
+/// ---------------------------------
+#if !defined(ESP8266) && !defined(ESP32)
+const char HTTP_TELEMETRY_TOPIC[] = PSTR("/api/v1/%s/telemetry");
+const char HTTP_ATTRIBUTES_TOPIC[] = PSTR("/api/v1/%s/attributes");
+const char HTTP_POST_PATH[] = PSTR("application/json");
+#endif
+
+// Publish data topics.
+const char ATTRIBUTE_TOPIC[] = PSTR("v1/devices/me/attributes");
+const char TELEMETRY_TOPIC[] = PSTR("v1/devices/me/telemetry");
+
+// RPC topics.
+const char RPC_SUBSCRIBE_TOPIC[] = PSTR("v1/devices/me/rpc/request/+");
+const char RPC_TOPIC[] = PSTR("v1/devices/me/rpc");
+
+// Firmware topics.
+const char FIRMWARE_RESPONSE_TOPIC[] = PSTR("v2/fw/response");
+
+// Shared attribute topics.
+const char ATTRIBUTE_REQUEST_TOPIC[] = PSTR("v1/devices/me/attributes/request/%u");
+const char ATTRIBUTE_RESPONSE_SUBSCRIBE_TOPIC[] = PSTR("v1/devices/me/attributes/response/+");
+const char ATTRIBUTE_RESPONSE_TOPIC[] = PSTR("v1/devices/me/attributes/response");
+
+// Provision topics.
+const char PROV_RESPONSE_TOPIC[] = PSTR("/provision/response");
+
+// Default login data.
+const char PROV_ACCESS_TOKEN[] = PSTR("provision");
+const char DEFAULT_CLIENT_ID[] = PSTR("TbDev");
+
+// Shared attribute request keys.
+const char SHARED_KEYS[] = PSTR("sharedKeys");
+const char SHARED_KEY[] = PSTR("shared");
+
+// RPC data keys.
+const char RPC_METHOD_KEY[] = PSTR("method");
+const char RPC_PARAMS_KEY[] = PSTR("params");
+const char RPC_REQUEST_KEY[] = PSTR("request");
+const char RPC_RESPONSE_KEY[] = PSTR("response");
+
+// Log messages.
+const char INVALID_BUFFER_SIZE[] = PSTR("PayloadSize (%u) to small for the given payloads size (%u)");
+const char MAX_RPC_EXCEEDED[] = PSTR("Too many rpc subscriptions, increase MaxFieldsAmt or unsubscribe");
+const char MAX_SHARED_ATT_UPDATE_EXCEEDED[] = PSTR("Too many shared attribute update callback subscriptions, increase MaxFieldsAmt or unsubscribe");
+const char MAX_SHARED_ATT_REQUEST_EXCEEDED[] = PSTR("Too many shared attribute request callback subscriptions, increase MaxFieldsAmt");
+const char NUMBER_PRINTF[] = PSTR("%u");
+const char COMMA = PSTR(',');
+const char NO_KEYS_TO_REQUEST[] = PSTR("No keys to request were given");
+const char REQUEST_ATT[] = PSTR("Requesting shared attributes transformed from (%s) into json (%s)");
+const char UNABLE_TO_SERIALIZE[] = PSTR("Unable to serialize data");
+const char UNABLE_TO_DE_SERIALIZE_RPC[] = PSTR("Unable to de-serialize RPC");
+const char UNABLE_TO_DE_SERIALIZE_ATT_REQUEST[] = PSTR("Unable to de-serialize shared attribute request");
+const char UNABLE_TO_DE_SERIALIZE_ATT_UPDATE[] = PSTR("Unable to de-serialize shared attribute update");
+const char RECEIVED_RPC_LOG_MESSAGE[] = PSTR("Received RPC:");
+const char RPC_METHOD_NULL[] = PSTR("RPC method is NULL");
+const char RPC_CB_NULL[] = PSTR("RPC callback or subscribed rpc method name is NULL");
+const char NO_RPC_PARAMS_PASSED[] = PSTR("No parameters passed with RPC, passing null JSON");
+const char CALLING_RPC[] = PSTR("Calling RPC:");
+const char RECEIVED_ATT_UPDATE[] = PSTR("Received shared attribute update");
+const char NOT_FOUND_ATT_UPDATE[] = PSTR("Shared attribute update key not found");
+const char ATT_CB_ID[] = PSTR("Shared attribute update callback id: (%u)");
+const char ATT_CB_IS_NULL[] = PSTR("Shared attribute update callback is NULL");
+const char ATT_CB_NO_KEYS[] = PSTR("No keys subscribed. Calling subscribed callback for any updated attributes (assumed to be subscribed to every possible key)");
+const char ATT_IS_NULL[] = PSTR("Subscribed shared attribute update key is NULL");
+const char ATT_IN_ARRAY[] = PSTR("Shared attribute update key: (%s) is subscribed");
+const char ATT_NO_CHANGE[] = PSTR("No keys that we subscribed too were changed, skipping callback");
+const char CALLING_ATT_CB[] = PSTR("Calling subscribed callback for updated shared attribute (%s)");
+const char RECEIVED_ATT[] = PSTR("Received shared attribute request");
+const char ATT_KEY_NOT_FOUND[] = PSTR("Shared attribute key not found");
+const char ATT_REQUEST_CB_IS_NULL[] = PSTR("Shared attribute request callback is NULL");
+const char CALLING_REQUEST_ATT_CB[] = PSTR("Calling subscribed callback for response id (%u)");
+const char TOO_MANY_JSON_FIELDS[] = PSTR("Too many JSON fields passed (%u), increase MaxFieldsAmt (%u) accordingly");
+const char CB_ON_MESSAGE[] = PSTR("Callback on_message from topic: (%s)");
+const char CONNECT_FAILED[] = PSTR("Connecting to server failed");
+
+#if defined(ESP8266) || defined(ESP32) || defined(ARDUINO_AVR_MEGA)
+// Claim topics.
+const char CLAIM_TOPIC[] = PSTR("v1/devices/me/claim");
+
+// Provision topics.
+const char PROV_REQUEST_TOPIC[] = PSTR("/provision/request");
+
+// Claim data keys.
+const char SECRET_KEY[] = PSTR("secretKey");
+const char DURATION_KEY[] = PSTR("durationMs");
+const char DEVICE_NAME_KEY[] = PSTR("deviceName");
+const char PROV_DEVICE_KEY[] = PSTR("provisionDeviceKey");
+const char PROV_DEVICE_SECRET_KEY[] = PSTR("provisionDeviceSecret");
+
+// Provision data keys.
+const char PROV_STATUS_KEY[] = PSTR("status");
+const char PROV_CRED_TYPE_KEY[] = PSTR("credentialsType");
+const char SUCCESS[] = PSTR("SUCCESS");
+const char PROV_CRED_TYPE_VALUE[] = PSTR("X509_CERTIFICATE");
+
+// Log messages.
+const char PROV_REQUEST[] = PSTR("Provision request:");
+const char UNABLE_TO_DE_SERIALIZE_PROV_RESPONSE[] = PSTR("Unable to de-serialize provision response");
+const char PROV_RESPONSE[] = PSTR("Process provisioning response");
+const char RECEIVED_PROV_RESPONSE[] = PSTR("Received provision response");
+const char X509_NOT_SUPPORTED[] = PSTR("Provision response contains X509_CERTIFICATE credentials, this is not supported yet");
+
+#if !defined(ARDUINO_AVR_MEGA)
+// Firmware topics.
+const char FIRMWARE_RESPONSE_SUBSCRIBE_TOPIC[] = PSTR("v2/fw/response/#");
+const char FIRMWARE_REQUEST_TOPIC[] = PSTR("v2/fw/request/0/chunk/%u");
+
+// Firmware data keys.
+const char CURR_FW_TITLE_KEY[] = PSTR("current_fw_title");
+const char CURR_FW_VER_KEY[] = PSTR("current_fw_version");
+const char CURR_FW_STATE_KEY[] = PSTR("current_fw_state");
+const char FW_VER_KEY[] = PSTR("fw_version");
+const char FW_TITLE_KEY[] = PSTR("fw_title");
+const char FW_CHKS_KEY[] = PSTR("fw_checksum");
+const char FW_CHKS_ALGO_KEY[] = PSTR("fw_checksum_algorithm");
+const char FW_SIZE_KEY[] = PSTR("fw_size");
+const char FW_CHECKSUM_VALUE[] = PSTR("MD5");
+const char FW_STATE_CHECKING[] = PSTR("CHECKING FIRMWARE");
+const char FW_STATE_NO_FW[] = PSTR("NO FIRMWARE FOUND");
+const char FW_STATE_UP_TO_DATE[] = PSTR("UP TO DATE");
+const char FW_STATE_INVALID_CHKS[] = PSTR("CHKS IS NOT MD5");
+const char FW_STATE_DOWNLOADING[] = PSTR("DOWNLOADING");
+const char FW_STATE_FAILED[] = PSTR("FAILED");
+const char FW_STATE_UPDATE_ERROR[] = PSTR("UPDATE ERROR");
+const char FW_STATE_CHKS_ERROR[] = PSTR("CHECKSUM ERROR");
+
+// Log messages.
+const char NO_FW[] = PSTR("No new firmware assigned on the given device");
+const char FW_UP_TO_DATE[] = PSTR("Firmware is already up to date");
+const char FW_NOT_FOR_US[] = PSTR("Firmware is not for us (title is different)");
+const char FW_CHKS_ALGO_NOT_SUPPORTED[] = PSTR("Checksum algorithm is not supported, please use MD5 only");
+const char PAGE_BREAK[] = PSTR("=================================");
+const char NEW_FW[] = PSTR("A new Firmware is available:");
+const char FROM_TOO[] = PSTR("(%s) => (%s)");
+const char DOWNLOADING_FW[] = PSTR("Attempting to download over MQTT...");
+const char NOT_ENOUGH_RAM[] = PSTR("Not enough RAM");
+const char SLASH = PSTR('/');
+const char UNABLE_TO_WRITE[] = PSTR("Unable to write firmware");
+const char UNABLE_TO_DOWNLOAD[] = PSTR("Unable to download firmware");
+const char FW_CHUNK[] = PSTR("Receive chunk (%i), with size (%u) bytes");
+const char ERROR_UPDATE_BEGIN[] = PSTR("Error during Update.begin");
+const char MD5_ACTUAL[] = PSTR("MD5 actual checksum: (%s)");
+const char MD5_EXPECTED[] = PSTR("MD5 expected checksum: (%s)");
+const char CHKS_VER_FAILED[] = PSTR("Checksum verification failed");
+const char CHKS_VER_SUCCESS[] = PSTR("Checksum is the same as expected");
+const char FW_UPDATE_SUCCESS[] = PSTR("Update success");
+#endif
+#endif
+
 // Telemetry record class, allows to store different data using common interface.
 class Telemetry {
     template<size_t PayloadSize, size_t MaxFieldsAmt, typename Logger>
@@ -252,7 +403,7 @@ class ThingsBoardSized
     // Connects to the specified ThingsBoard server and port.
     // Access token is used to authenticate a client.
     // Returns true on success, false otherwise.
-    inline const bool connect(const char *host, const char *access_token = "provision", int port = 1883, const char *client_id = "TbDev", const char *password = NULL) {
+    inline const bool connect(const char *host, const char *access_token = PROV_ACCESS_TOKEN, int port = 1883, const char *client_id = DEFAULT_CLIENT_ID, const char *password = NULL) {
       if (!host) {
         return false;
       }
@@ -266,7 +417,10 @@ class ThingsBoardSized
       this->Firmware_OTA_Unsubscribe();
 #endif
       m_client.setServer(host, port);
-      bool connection_result = m_client.connect(client_id, access_token, password);
+      const bool connection_result = m_client.connect(client_id, access_token, password);
+      if (!connection_result) {
+        Logger::log(CONNECT_FAILED);
+      }
       return connection_result;
     }
 
@@ -290,18 +444,18 @@ class ThingsBoardSized
 
 #if defined(ESP8266) || defined(ESP32) || defined(ARDUINO_AVR_MEGA)
 
-    inline const bool sendClaimingRequest(const char *secretKey, unsigned int durationMs) {
+    inline const bool sendClaimingRequest(const char *secretKey, uint32_t durationMs) {
       StaticJsonDocument<JSON_OBJECT_SIZE(1)> requestBuffer;
       JsonObject resp_obj = requestBuffer.to<JsonObject>();
 
-      resp_obj[PSTR("secretKey")] = secretKey;
-      resp_obj[PSTR("durationMs")] = durationMs;
+      resp_obj[SECRET_KEY] = secretKey;
+      resp_obj[DURATION_KEY] = durationMs;
 
       uint8_t objectSize = JSON_STRING_SIZE(measureJson(requestBuffer));
       char responsePayload[objectSize];
       serializeJson(resp_obj, responsePayload, objectSize);
 
-      return m_client.publish(PSTR("v1/devices/me/claim"), responsePayload);
+      return m_client.publish(CLAIM_TOPIC, responsePayload);
     }
 
     // Provisioning API
@@ -310,17 +464,17 @@ class ThingsBoardSized
       StaticJsonDocument<JSON_OBJECT_SIZE(3)> requestBuffer;
       JsonObject requestObject = requestBuffer.to<JsonObject>();
 
-      requestObject[PSTR("deviceName")] = deviceName;
-      requestObject[PSTR("provisionDeviceKey")] = provisionDeviceKey;
-      requestObject[PSTR("provisionDeviceSecret")] = provisionDeviceSecret;
+      requestObject[DEVICE_NAME_KEY] = deviceName;
+      requestObject[PROV_DEVICE_KEY] = provisionDeviceKey;
+      requestObject[PROV_DEVICE_SECRET_KEY] = provisionDeviceSecret;
 
       uint8_t objectSize = JSON_STRING_SIZE(measureJson(requestBuffer));
       char requestPayload[objectSize];
       serializeJson(requestObject, requestPayload, objectSize);
 
-      Logger::log(PSTR("Provision request:"));
+      Logger::log(PROV_REQUEST);
       Logger::log(requestPayload);
-      return m_client.publish(PSTR("/provision/request"), requestPayload);
+      return m_client.publish(PROV_REQUEST_TOPIC, requestPayload);
     }
 
 #endif
@@ -361,15 +515,33 @@ class ThingsBoardSized
 
     // Sends custom JSON telemetry string to the ThingsBoard.
     inline const bool sendTelemetryJson(const char *json) {
-      return m_client.publish(PSTR("v1/devices/me/telemetry"), json);
+      if (json == nullptr) {
+        return false;
+      }
+
+      const uint32_t json_size = JSON_STRING_SIZE(strlen(json));
+      if (json_size > PayloadSize) {
+        char message[JSON_STRING_SIZE(strlen(INVALID_BUFFER_SIZE)) + detect_size(PayloadSize) + detect_size(json_size)];
+        snprintf_P(message, sizeof(message), INVALID_BUFFER_SIZE, PayloadSize, json_size);
+        Logger::log(message);
+        return false;
+      }
+      return m_client.publish(TELEMETRY_TOPIC, json);
     }
 
     // Sends custom JSON telemetry JsonObject to the ThingsBoard.
     inline const bool sendTelemetryJson(const JsonObject& jsonObject) {
-      uint32_t json_size = JSON_STRING_SIZE(measureJson(jsonObject));
+      const uint32_t json_object_size = jsonObject.size();
+      if (MaxFieldsAmt < json_object_size) {
+        char message[JSON_STRING_SIZE(strlen(TOO_MANY_JSON_FIELDS)) + detect_size(json_object_size) + detect_size(MaxFieldsAmt)];
+        snprintf_P(message, sizeof(message), TOO_MANY_JSON_FIELDS, json_object_size, MaxFieldsAmt);
+        Logger::log(message);
+        return false;
+      }
+      const uint32_t json_size = JSON_STRING_SIZE(measureJson(jsonObject));
       char json[json_size];
       serializeJson(jsonObject, json, json_size);
-      return m_client.publish(PSTR("v1/devices/me/telemetry"), json);
+      return sendTelemetryJson(json);
     }
 
     //----------------------------------------------------------------------------
@@ -408,15 +580,33 @@ class ThingsBoardSized
 
     // Sends custom JSON with attributes to the ThingsBoard.
     inline const bool sendAttributeJSON(const char *json) {
-      return m_client.publish("v1/devices/me/attributes", json);
+      if (json == nullptr) {
+        return false;
+      }
+
+      const uint32_t json_size = JSON_STRING_SIZE(strlen(json));
+      if (json_size > PayloadSize) {
+        char message[JSON_STRING_SIZE(strlen(INVALID_BUFFER_SIZE)) + detect_size(PayloadSize) + detect_size(json_size)];
+        snprintf_P(message, sizeof(message), INVALID_BUFFER_SIZE, PayloadSize, json_size);
+        Logger::log(message);
+        return false;
+      }
+      return m_client.publish(ATTRIBUTE_TOPIC, json);
     }
 
     // Sends custom JsonObject with attributes to the ThingsBoard.
     inline const bool sendAttributeJSON(const JsonObject& jsonObject) {
-      uint32_t json_size = JSON_STRING_SIZE(measureJson(jsonObject));
+      const uint32_t json_object_size = jsonObject.size();
+      if (MaxFieldsAmt < json_object_size) {
+        char message[JSON_STRING_SIZE(strlen(TOO_MANY_JSON_FIELDS)) + detect_size(json_object_size) + detect_size(MaxFieldsAmt)];
+        snprintf_P(message, sizeof(message), TOO_MANY_JSON_FIELDS, json_object_size, MaxFieldsAmt);
+        Logger::log(message);
+        return false;
+      }
+      const uint32_t json_size = JSON_STRING_SIZE(measureJson(jsonObject));
       char json[json_size];
       serializeJson(jsonObject, json, json_size);
-      return m_client.publish("v1/devices/me/attributes", json);
+      return sendAttributeJSON(json);
     }
 
     //----------------------------------------------------------------------------
@@ -425,10 +615,10 @@ class ThingsBoardSized
     // Subscribes multiple RPC callbacks.
     inline const bool RPC_Subscribe(const std::vector<RPC_Callback>& callbacks) {
       if (m_rpcCallbacks.size() + callbacks.size() > m_rpcCallbacks.capacity()) {
-        Logger::log(PSTR("Too many rpc subscriptions, increase MaxFieldsAmt or unsubscribe."));
+        Logger::log(MAX_RPC_EXCEEDED);
         return false;
       }
-      if (!m_client.subscribe(PSTR("v1/devices/me/rpc/request/+"))) {
+      if (!m_client.subscribe(RPC_SUBSCRIBE_TOPIC)) {
         return false;
       }
 
@@ -440,10 +630,10 @@ class ThingsBoardSized
     // Subscribe one RPC callback.
     inline const bool RPC_Subscribe(const RPC_Callback& callback) {
       if (m_rpcCallbacks.size() + 1 > m_rpcCallbacks.capacity()) {
-        Logger::log(PSTR("Too many rpc subscriptions, increase MaxFieldsAmt or unsubscribe."));
+        Logger::log(MAX_RPC_EXCEEDED);
         return false;
       }
-      if (!m_client.subscribe(PSTR("v1/devices/me/rpc/request/+"))) {
+      if (!m_client.subscribe(RPC_SUBSCRIBE_TOPIC)) {
         return false;
       }
 
@@ -455,113 +645,165 @@ class ThingsBoardSized
     inline const bool RPC_Unsubscribe() {
       // Empty all callbacks.
       m_rpcCallbacks.clear();
-      return m_client.unsubscribe(PSTR("v1/devices/me/rpc/request/+"));
+      return m_client.unsubscribe(RPC_SUBSCRIBE_TOPIC);
     }
 
     //----------------------------------------------------------------------------
     // Firmware OTA API
 
 #if defined(ESP8266) || defined(ESP32)
-    inline const bool Firmware_Update(const char* currFwTitle, const char* currFwVersion) {
-      m_fwState.clear();
-      m_fwTitle.clear();
-      m_fwVersion.clear();
+    inline const bool Start_Firmware_Update(const char* currFwTitle, const char* currFwVersion, const std::function<void(const bool&)>& updatedCallback) {
+      m_fwState = nullptr;
+      m_fwChecksum = nullptr;
 
       // Send current firmware version
-      if (!Firmware_Send_FW_Info(currFwTitle, currFwVersion)) {
+      if (currFwTitle == nullptr || currFwVersion == nullptr) {
+        return false;
+      }
+      else if (!Firmware_Send_FW_Info(currFwTitle, currFwVersion)) {
         return false;
       }
 
       // Update state
-      Firmware_Send_State("CHECKING FIRMWARE");
+      if (!Firmware_Send_State(FW_STATE_CHECKING)) {
+        return false;
+      }
 
       // Request the firmware informations
-      const std::vector<const char*> sharedKeys {"fw_checksum", "fw_checksum_algorithm", "fw_size", "fw_title", "fw_version"};
-      if (!Shared_Attributes_Request(sharedKeys, Shared_Attribute_Request_Callback())) {
+      const std::vector<const char*> fwSharedKeys {FW_CHKS_KEY, FW_CHKS_ALGO_KEY, FW_SIZE_KEY, FW_TITLE_KEY, FW_VER_KEY};
+      if (!Shared_Attributes_Request(fwSharedKeys, Shared_Attribute_Request_Callback(std::bind(&ThingsBoardSized::Firmware_Shared_Attribute_Received, this, std::placeholders::_1)))) {
         return false;
       }
 
-      // Wait receive m_fwVersion and m_fwTitle
-      unsigned long timeout = millis() + 3000;
-      do {
-        delay(5);
-        loop();
-      } while (m_fwVersion.isEmpty() && m_fwTitle.isEmpty() && (timeout >= millis()));
+      // Set private members needed for update.
+      m_currFwTitle = currFwTitle;
+      m_currFwVersion = currFwVersion;
+      m_fwUpdatedCallback = updatedCallback;
+      return true;
+    }
 
+    inline const bool Firmware_Send_FW_Info(const char* currFwTitle, const char* currFwVersion) {
+      // Send our firmware title and version
+      StaticJsonDocument<JSON_OBJECT_SIZE(2)> currentFirmwareInfo;
+      JsonObject currentFirmwareInfoObject = currentFirmwareInfo.to<JsonObject>();
+
+      currentFirmwareInfoObject[CURR_FW_TITLE_KEY] = currFwTitle;
+      currentFirmwareInfoObject[CURR_FW_VER_KEY] = currFwVersion;
+      return sendTelemetryJson(currentFirmwareInfoObject);
+    }
+
+    inline const bool Firmware_Send_State(const char* currFwState) {
+      // Send our firmware title and version
+      StaticJsonDocument<JSON_OBJECT_SIZE(1)> currentFirmwareState;
+      JsonObject currentFirmwareStateObject = currentFirmwareState.to<JsonObject>();
+
+      currentFirmwareStateObject[CURR_FW_STATE_KEY] = currFwState;
+      return sendTelemetryJson(currentFirmwareStateObject);
+    }
+
+    inline const bool Firmware_OTA_Subscribe() {
+      if (!m_client.subscribe(FIRMWARE_RESPONSE_SUBSCRIBE_TOPIC)) {
+        return false;
+      }
+
+      return true;
+    }
+
+    inline const bool Firmware_OTA_Unsubscribe() {
+      if (!m_client.unsubscribe(FIRMWARE_RESPONSE_SUBSCRIBE_TOPIC)) {
+        return false;
+      }
+
+      return true;
+    }
+
+    inline void Firmware_Shared_Attribute_Received(const Shared_Attribute_Data& data) {
       // Check if firmware is available for our device
-      if (m_fwVersion.isEmpty() || m_fwTitle.isEmpty()) {
-        Logger::log(PSTR("No firmware found !"));
-        Firmware_Send_State("NO FIRMWARE FOUND");
-        return false;
+      if (!data.containsKey(FW_VER_KEY) || !data.containsKey(FW_TITLE_KEY)) {
+        Logger::log(NO_FW);
+        Firmware_Send_State(FW_STATE_NO_FW);
+        return;
       }
+
+      const char* fw_title = data[FW_TITLE_KEY].as<const char*>();
+      const char* fw_version = data[FW_VER_KEY].as<const char*>();
+      m_fwChecksum = data[FW_CHKS_KEY].as<const char*>();
+      const char* fw_checksum_algorithm = data[FW_CHKS_ALGO_KEY].as<const char*>();
+      m_fwSize = data[FW_SIZE_KEY].as<const uint16_t>();
 
       // If firmware is the same, we do not update it
-      if (strncmp(currFwTitle, m_fwTitle.c_str(), m_fwTitle.length()) == 0 &&
-          strncmp(currFwVersion, m_fwVersion.c_str(), m_fwVersion.length()) == 0) {
-        Logger::log(PSTR("Firmware is already up to date !"));
-        Firmware_Send_State("UP TO DATE");
-        return false;
+      if (strncmp_P(m_currFwTitle, fw_title, strlen(m_currFwTitle)) == 0 && strncmp_P(m_currFwVersion, fw_version, strlen(m_currFwVersion) == 0)) {
+        Logger::log(FW_UP_TO_DATE);
+        Firmware_Send_State(FW_STATE_UP_TO_DATE);
+        return;
       }
 
       // If firmware title is not the same, we quit now
-      if (strncmp(currFwTitle, m_fwTitle.c_str(), m_fwTitle.length()) != 0) {
-        Logger::log(PSTR("Firmware is not for us (title is different) !"));
-        Firmware_Send_State("NO FIRMWARE FOUND");
-        return false;
+      if (strncmp_P(m_currFwTitle, fw_title, strlen(m_currFwTitle)) != 0) {
+        Logger::log(FW_NOT_FOR_US);
+        Firmware_Send_State(FW_STATE_NO_FW);
+        return;
       }
 
-      if (!m_fwChecksumAlgorithm.equals("MD5")) {
-        Logger::log(PSTR("Checksum algorithm is not supported, please use MD5 only"));
-        Firmware_Send_State("CHKS IS NOT MD5");
-        return false;
+      if (strncmp_P(FW_CHECKSUM_VALUE, fw_checksum_algorithm, strlen(FW_CHECKSUM_VALUE)) != 0) {
+        Logger::log(FW_CHKS_ALGO_NOT_SUPPORTED);
+        Firmware_Send_State(FW_STATE_INVALID_CHKS);
+        return;
       }
 
-      Logger::log(PSTR("================================="));
-      Logger::log(PSTR("A new Firmware is available :"));
-      char firmware[5U + strlen(currFwVersion) + m_fwVersion.length()];
-      snprintf_P(firmware, sizeof(firmware), PSTR("%s => %s"), currFwVersion, m_fwVersion.c_str());
+      // Subscribe to the needed OTA fw topics.
+      Firmware_OTA_Subscribe();
+
+      Logger::log(PAGE_BREAK);
+      Logger::log(NEW_FW);
+      char firmware[JSON_STRING_SIZE(strlen(FROM_TOO)) + JSON_STRING_SIZE(strlen(m_currFwVersion)) + JSON_STRING_SIZE(strlen(fw_version))];
+      snprintf_P(firmware, sizeof(firmware), FROM_TOO, m_currFwVersion, fw_version);
       Logger::log(firmware);
-      Logger::log(PSTR("Try to download it..."));
+      Logger::log(DOWNLOADING_FW);
 
-      int chunkSize = 4096; // maybe less if we don't have enough RAM
-      int numberOfChunk = static_cast<int>(m_fwSize/chunkSize) + 1;
-      int currChunk = 0;
-      int nbRetry = 3;
+      const uint16_t chunkSize = 4096U; // maybe less if we don't have enough RAM
+      const uint16_t numberOfChunk = static_cast<uint16_t>(m_fwSize / chunkSize) + 1U;
+      uint16_t currChunk = 0U;
+      uint8_t nbRetry = 3U;
+
+      // Get the previous buffer size and cache it so the previous settings can be restored.
+      const uint16_t previousBufferSize = m_client.getBufferSize();
+      const bool changeBufferSize = previousBufferSize < (chunkSize + 50U);
 
       // Increase size of receive buffer
-      if (!m_client.setBufferSize(chunkSize + 50)) {
-        Logger::log(PSTR("Not enough RAM"));
-        return false;
+      if (changeBufferSize && !m_client.setBufferSize(chunkSize + 50U)) {
+        Logger::log(NOT_ENOUGH_RAM);
+        return;
       }
 
       // Update state
-      Firmware_Send_State("DOWNLOADING");
+      Firmware_Send_State(FW_STATE_DOWNLOADING);
 
-      char size[1U + detect_size(chunkSize)];
+      char size[JSON_STRING_SIZE(strlen(NUMBER_PRINTF)) + detect_size(chunkSize)];
       // Download the firmware
       do {
-        char topic[23U + detect_size(currChunk)]; // Size adjuts dynamically to the current length of the currChunk number to ensure we don't cut it out of the topic string.
-        snprintf_P(topic, sizeof(topic), PSTR("v2/fw/request/0/chunk/%i"), currChunk);
-        snprintf_P(size, sizeof(size), PSTR("%i"), chunkSize);
+        char topic[JSON_STRING_SIZE(strlen(FIRMWARE_REQUEST_TOPIC)) + detect_size(currChunk)]; // Size adjuts dynamically to the current length of the currChunk number to ensure we don't cut it out of the topic string.
+        snprintf_P(topic, sizeof(topic), FIRMWARE_REQUEST_TOPIC, currChunk);
+        snprintf_P(size, sizeof(size), NUMBER_PRINTF, chunkSize);
         m_client.publish(topic, size);
 
-        timeout = millis() + 3000U; // Amount of time we wait until we declare the download as failed in milliseconds.
+        const uint64_t timeout = millis() + 3000U; // Amount of time we wait until we declare the download as failed in milliseconds.
         do {
           delay(5);
           loop();
         } while ((m_fwChunkReceive != currChunk) && (timeout >= millis()));
 
         if (m_fwChunkReceive == currChunk) {
-          // Check if chunk is not the last
+          // Check if the current chunk is not the last one.
           if (numberOfChunk != (currChunk + 1)) {
-            // Check if state is OK
-            if ((m_fwState == "DOWNLOADING")) {
+            // Check if state is still DOWNLOADING and did not fail.
+            if (strncmp_P(FW_STATE_DOWNLOADING, m_fwState, strlen(FW_STATE_DOWNLOADING) == 0)) {
               currChunk++;
             }
             else {
               nbRetry--;
               if (nbRetry == 0) {
-                Logger::log(PSTR("Unable to write firmware"));
+                Logger::log(UNABLE_TO_WRITE);
                 break;
               }
             }
@@ -571,113 +813,93 @@ class ThingsBoardSized
             currChunk++;
           }
         }
-
         // Timeout
         else {
           nbRetry--;
           if (nbRetry == 0) {
-            Logger::log(PSTR("Unable to download firmware"));
+            Logger::log(UNABLE_TO_DOWNLOAD);
             break;
           }
         }
-
       } while (numberOfChunk != currChunk);
 
+      // Buffer size has been set to another value by the method return to the previous value.
+      if (changeBufferSize) {
+        m_client.setBufferSize(previousBufferSize);
+      }
+
+      // Unsubscribe from now not needed topics anymore.
+      Firmware_OTA_Unsubscribe();
+
+      bool success = false;
       // Update current_fw_title and current_fw_version if updating was a success.
-      if (m_fwState == "SUCCESS") {
-        Firmware_Send_FW_Info(m_fwTitle.c_str(), m_fwVersion.c_str());
-        Firmware_Send_State(m_fwState.c_str());
-        return true;
+      if (strncmp_P(SUCCESS, m_fwState, strlen(SUCCESS)) == 0) {
+        Firmware_Send_FW_Info(fw_title, fw_version);
+        Firmware_Send_State(SUCCESS);
+        success = true;
       }
       else {
-        Firmware_Send_State("FAILED");
-      }
-      return false;
-    }
-
-    inline const bool Firmware_Send_FW_Info(const char* currFwTitle, const char* currFwVersion) {
-      // Send our firmware title and version
-      StaticJsonDocument<JSON_OBJECT_SIZE(2)> currentFirmwareInfo;
-      JsonObject currentFirmwareInfoObject = currentFirmwareInfo.to<JsonObject>();
-
-      currentFirmwareInfoObject[PSTR("current_fw_title")] = currFwTitle;
-      currentFirmwareInfoObject[PSTR("current_fw_version")] = currFwVersion;
-      return sendTelemetryJson(currentFirmwareInfoObject);
-    }
-
-    inline const bool Firmware_Send_State(const char* currFwState) {
-      // Send our firmware title and version
-      StaticJsonDocument<JSON_OBJECT_SIZE(1)> currentFirmwareState;
-      JsonObject currentFirmwareStateObject = currentFirmwareState.to<JsonObject>();
-
-      currentFirmwareStateObject[PSTR("current_fw_state")] = currFwState;
-      return sendTelemetryJson(currentFirmwareStateObject);
-    }
-
-    inline const bool Firmware_OTA_Subscribe() {
-      if (!m_client.subscribe(PSTR("v2/fw/response/#"))) {
-        return false;
+        Firmware_Send_State(FW_STATE_FAILED);
       }
 
-      return true;
-    }
-
-    inline const bool Firmware_OTA_Unsubscribe() {
-      if (!m_client.unsubscribe(PSTR("v2/fw/response/#"))) {
-        return false;
+      if (m_fwUpdatedCallback != nullptr) {
+        m_fwUpdatedCallback(success);
       }
-
-      return true;
     }
 #endif
 
     //----------------------------------------------------------------------------
     // Shared attributes API
 
-    inline const bool Shared_Attributes_Request(const std::vector<const char*>& att, Shared_Attribute_Request_Callback& callback) {
+    inline const bool Shared_Attributes_Request(const std::vector<const char*>& attributes, Shared_Attribute_Request_Callback& callback) {
       StaticJsonDocument<JSON_OBJECT_SIZE(1)> requestBuffer;
       JsonObject requestObject = requestBuffer.to<JsonObject>();
 
-      std::string sharedKeys = "";
-      for (const char* attribute : att) {
+      std::string sharedKeys;
+      for (const char* attribute : attributes) {
         // Check if the given attribute is null, if it is skip it.
         if (attribute == nullptr) {
           continue;
         }
         sharedKeys.append(attribute);
-        sharedKeys.append(",");
+        sharedKeys.push_back(COMMA);
       }
 
       // Check if any sharedKeys were requested.
       if (sharedKeys.empty()) {
-        Logger::log(PSTR("No keys to request were given."));
+        Logger::log(NO_KEYS_TO_REQUEST);
         return false;
       }
 
       // Remove latest not needed ,
       sharedKeys.pop_back();
 
-      requestObject[PSTR("sharedKeys")] = sharedKeys.c_str();
+      requestObject[SHARED_KEYS] = sharedKeys.c_str();
       int objectSize = measureJson(requestBuffer) + 1;
       char buffer[objectSize];
       serializeJson(requestObject, buffer, objectSize);
+
+      // Print requested keys.
+      char message[JSON_STRING_SIZE(strlen(REQUEST_ATT)) + sharedKeys.length() + JSON_STRING_SIZE(strlen(buffer))];
+      snprintf_P(message, sizeof(message), REQUEST_ATT, sharedKeys.c_str(), buffer);
+      Logger::log(message);
 
       m_requestId++;
       callback.m_request_id = m_requestId;
       Shared_Attributes_Request_Subscribe(callback);
 
-      char topic[34U + detect_size(m_requestId)];
-      snprintf_P(topic, sizeof(topic), PSTR("v1/devices/me/attributes/request/%u"), m_requestId);
+      char topic[JSON_STRING_SIZE(strlen(ATTRIBUTE_REQUEST_TOPIC)) + detect_size(m_requestId)];
+      snprintf_P(topic, sizeof(topic), ATTRIBUTE_REQUEST_TOPIC, m_requestId);
       return m_client.publish(topic, buffer);
     }
 
     // Subscribes multiple Shared attributes callbacks.
     inline const bool Shared_Attributes_Subscribe(const std::vector<Shared_Attribute_Callback>& callbacks) {
       if (m_sharedAttributeUpdateCallbacks.size() + callbacks.size() > m_sharedAttributeUpdateCallbacks.capacity()) {
-        Logger::log(PSTR("Too many shared attribute update callback subscriptions, increase MaxFieldsAmt or unsubscribe."));
+        Logger::log(MAX_SHARED_ATT_UPDATE_EXCEEDED);
         return false;
       }
-      if (!m_client.subscribe(PSTR("v1/devices/me/attributes"))) {
+      if (!m_client.subscribe(ATTRIBUTE_TOPIC)) {
         return false;
       }
 
@@ -688,11 +910,11 @@ class ThingsBoardSized
 
     // Subscribe one Shared attributes callback.
     bool Shared_Attributes_Subscribe(const Shared_Attribute_Callback& callback) {
-      if (m_sharedAttributeUpdateCallbacks.size() + 1 > m_sharedAttributeUpdateCallbacks.capacity()) {
-        Logger::log(PSTR("Too many shared attribute update callback subscriptions, increase MaxFieldsAmt or unsubscribe."));
+      if (m_sharedAttributeUpdateCallbacks.size() + 1U > m_sharedAttributeUpdateCallbacks.capacity()) {
+        Logger::log(MAX_SHARED_ATT_UPDATE_EXCEEDED);
         return false;
       }
-      if (!m_client.subscribe(PSTR("v1/devices/me/attributes"))) {
+      if (!m_client.subscribe(ATTRIBUTE_TOPIC)) {
         return false;
       }
 
@@ -704,7 +926,7 @@ class ThingsBoardSized
     inline const bool Shared_Attributes_Unsubscribe() {
       // Empty all callbacks.
       m_sharedAttributeUpdateCallbacks.clear();
-      if (!m_client.unsubscribe(PSTR("v1/devices/me/attributes"))) {
+      if (!m_client.unsubscribe(ATTRIBUTE_TOPIC)) {
         return false;
       }
       return true;
@@ -717,7 +939,7 @@ class ThingsBoardSized
 
 #if defined(ESP8266) || defined(ESP32) || defined(ARDUINO_AVR_MEGA)
     inline const bool Provision_Subscribe(const Provision_Callback callback) {
-      if (!m_client.subscribe(PSTR("/provision/response"))) {
+      if (!m_client.subscribe(PROV_RESPONSE_TOPIC)) {
         return false;
       }
       m_provisionCallback = callback;
@@ -725,7 +947,7 @@ class ThingsBoardSized
     }
 
     inline const bool Provision_Unsubscribe() {
-      if (!m_client.unsubscribe(PSTR("/provision/response"))) {
+      if (!m_client.unsubscribe(PROV_RESPONSE_TOPIC)) {
         return false;
       }
       return true;
@@ -735,8 +957,8 @@ class ThingsBoardSized
   private:
 
     // Returns the length in character places of a given signed number.
-    inline const uint8_t detect_size(const int32_t number) {
-      return snprintf(nullptr, 0, "%i", number);
+    inline const uint8_t detect_size(const uint32_t number) {
+      return snprintf_P(nullptr, 0U, NUMBER_PRINTF, number);
     }
 
     // Reserves size of callback vectors to improve performance
@@ -750,10 +972,10 @@ class ThingsBoardSized
     // Subscribe one Shared attributes request callback.
     inline const bool Shared_Attributes_Request_Subscribe(const Shared_Attribute_Request_Callback& callback) {
       if (m_sharedAttributeRequestCallbacks.size() + 1 > m_sharedAttributeRequestCallbacks.capacity()) {
-        Logger::log(PSTR("Too many shared attribute request callback subscriptions, increase MaxFieldsAmt."));
+        Logger::log(MAX_SHARED_ATT_REQUEST_EXCEEDED);
         return false;
       }
-      if (!m_client.subscribe(PSTR("v1/devices/me/attributes/response/+"))) {
+      if (!m_client.subscribe(ATTRIBUTE_RESPONSE_SUBSCRIBE_TOPIC)) {
         return false;
       }
 
@@ -765,7 +987,7 @@ class ThingsBoardSized
     inline const bool Shared_Attributes_Request_Unsubscribe() {
       // Empty all callbacks.
       m_sharedAttributeRequestCallbacks.clear();
-      if (!m_client.unsubscribe(PSTR("v1/devices/attributes/response/+"))) {
+      if (!m_client.unsubscribe(ATTRIBUTE_RESPONSE_SUBSCRIBE_TOPIC)) {
         return false;
       }
       return true;
@@ -775,70 +997,64 @@ class ThingsBoardSized
     template<typename T>
     inline const bool sendKeyval(const char *key, T value, bool telemetry = true) {
       Telemetry t(key, value);
-
-      char payload[PayloadSize];
-      {
-        Telemetry t(key, value);
-        StaticJsonDocument<JSON_OBJECT_SIZE(1)>jsonBuffer;
-        JsonVariant object = jsonBuffer.template to<JsonVariant>();
-        if (t.serializeKeyval(object) == false) {
-          Logger::log(PSTR("unable to serialize data"));
-          return false;
-        }
-
-        if (JSON_STRING_SIZE(measureJson(jsonBuffer)) > PayloadSize) {
-          Logger::log(PSTR("too small buffer for JSON data"));
-          return false;
-        }
-        serializeJson(object, payload, sizeof(payload));
+      StaticJsonDocument<JSON_OBJECT_SIZE(1)>jsonBuffer;
+      JsonVariant object = jsonBuffer.template to<JsonVariant>();
+      if (!t.serializeKeyval(object)) {
+        Logger::log(UNABLE_TO_SERIALIZE);
+        return false;
       }
-      return telemetry ? sendTelemetryJson(payload) : sendAttributeJSON(payload);
+
+      return telemetry ? sendTelemetryJson(object) : sendAttributeJSON(object);
     }
 
     // Processes RPC message
-    inline void process_rpc_message(char* topic, uint8_t* payload, unsigned int length) {
+    inline void process_rpc_message(char* topic, uint8_t* payload, uint32_t length) {
       RPC_Response r;
       {
         StaticJsonDocument<JSON_OBJECT_SIZE(MaxFieldsAmt)> jsonBuffer;
         DeserializationError error = deserializeJson(jsonBuffer, payload, length);
         if (error) {
-          Logger::log(PSTR("unable to de-serialize RPC"));
+          Logger::log(UNABLE_TO_DE_SERIALIZE_RPC);
           return;
         }
         const JsonObject &data = jsonBuffer.template as<JsonObject>();
-        const char *methodName = data[PSTR("method")];
-        const char *params = data[PSTR("params")];
+        const char *methodName = data[RPC_METHOD_KEY].as<const char*>();
+        const char *params = data[RPC_PARAMS_KEY].as<const char*>();
 
         if (methodName) {
-          Logger::log(PSTR("received RPC:"));
+          Logger::log(RECEIVED_RPC_LOG_MESSAGE);
           Logger::log(methodName);
         } else {
-          Logger::log(PSTR("RPC method is NULL"));
+          Logger::log(RPC_METHOD_NULL);
           return;
         }
 
         for (const RPC_Callback& callback : m_rpcCallbacks) {
-          // Strcmp returns the ascis value difference of the ascii characters that are different,
+          if (callback.m_cb == nullptr || callback.m_name == nullptr) {
+            Logger::log(RPC_CB_NULL);
+            continue;
+          }
+          // Strncmp returns the ascis value difference of the ascii characters that are different,
           // meaning 0 is the same string and less and more than 0 is the difference in ascci values between the 2 chararacters.
-          if (callback.m_cb == nullptr || strcmp(callback.m_name, methodName) != 0) {
+          else if (strncmp(callback.m_name, methodName, strlen(callback.m_name)) != 0) {
             continue;
           }
 
-          Logger::log(PSTR("calling RPC:"));
+          Logger::log(CALLING_RPC);
           Logger::log(methodName);
           // Do not inform client, if parameter field is missing for some reason
-          if (!data.containsKey("params")) {
-            Logger::log(PSTR("no parameters passed with RPC, passing null JSON"));
+          if (!data.containsKey(RPC_PARAMS_KEY)) {
+            Logger::log(NO_RPC_PARAMS_PASSED);
           }
 
           // try to de-serialize params
           StaticJsonDocument<JSON_OBJECT_SIZE(MaxFieldsAmt)> doc;
           DeserializationError err_param = deserializeJson(doc, params);
           //if failed to de-serialize params then send JsonObject instead
-          Logger::log(PSTR("params:"));
+          Logger::log(RPC_PARAMS_KEY);
           if (err_param) {
-            Logger::log(data[PSTR("params")].as<String>().c_str());
-            r = callback.m_cb(data[PSTR("params")]);
+            Logger::log(data[RPC_PARAMS_KEY].as<const char*>());
+            r = callback.m_cb(data[RPC_PARAMS_KEY]);
           } else {
             Logger::log(params);
             const JsonObject &param = doc.template as<JsonObject>();
@@ -855,19 +1071,23 @@ class ThingsBoardSized
       JsonVariant resp_obj = respBuffer.template to<JsonVariant>();
 
       if (r.serializeKeyval(resp_obj) == false) {
-        Logger::log(PSTR("unable to serialize data"));
+        Logger::log(UNABLE_TO_SERIALIZE);
         return;
       }
 
-      if (JSON_STRING_SIZE(measureJson(respBuffer)) > PayloadSize) {
-        Logger::log(PSTR("too small buffer for JSON data"));
+      const uint32_t json_size = JSON_STRING_SIZE(measureJson(respBuffer));
+      if (json_size > PayloadSize) {
+        char message[JSON_STRING_SIZE(strlen(INVALID_BUFFER_SIZE)) + detect_size(PayloadSize) + detect_size(json_size)];
+        snprintf_P(message, sizeof(message), INVALID_BUFFER_SIZE, PayloadSize, json_size);
+        Logger::log(message);
         return;
       }
       serializeJson(resp_obj, responsePayload, sizeof(responsePayload));
 
       String responseTopic = topic;
-      responseTopic.replace("request", "response");
-      Logger::log(PSTR("response:"));
+      responseTopic.replace(RPC_REQUEST_KEY, RPC_RESPONSE_KEY);
+      Logger::log(RPC_RESPONSE_KEY);
+      Logger::log(responseTopic.c_str());
       Logger::log(responsePayload);
       m_client.publish(responseTopic.c_str(), responsePayload);
     }
@@ -875,17 +1095,17 @@ class ThingsBoardSized
 #if defined(ESP8266) || defined(ESP32)
 
     // Processes firmware response
-    inline void process_firmware_response(char* topic, uint8_t* payload, unsigned int length) {
-      static unsigned int sizeReceive = 0;
+    inline void process_firmware_response(char* topic, uint8_t* payload, uint32_t length) {
+      static uint32_t sizeReceive = 0;
       static MD5Builder md5;
 
-      m_fwChunkReceive = atoi(strrchr(topic, '/') + 1);
+      m_fwChunkReceive = atoi(strrchr(topic, SLASH) + 1U);
 
-      char message[37U + detect_size(m_fwChunkReceive) + detect_size(length)];
-      snprintf_P(message, sizeof(message), PSTR("Receive chunk (%i), with size (%u) bytes"), m_fwChunkReceive, length);
+      char message[JSON_STRING_SIZE(strlen(FW_CHUNK)) + detect_size(m_fwChunkReceive) + detect_size(length)];
+      snprintf_P(message, sizeof(message), FW_CHUNK, m_fwChunkReceive, length);
       Logger::log(message);
 
-      m_fwState = "FAILED";
+      m_fwState = FW_STATE_FAILED;
 
       if (m_fwChunkReceive == 0) {
         sizeReceive = 0;
@@ -894,16 +1114,16 @@ class ThingsBoardSized
 
         // Initialize Flash
         if (!Update.begin(m_fwSize)) {
-          Logger::log(PSTR("Error during Update.begin"));
-          m_fwState = "UPDATE ERROR";
+          Logger::log(ERROR_UPDATE_BEGIN);
+          m_fwState = FW_STATE_UPDATE_ERROR;
           return;
         }
       }
 
       // Write data to Flash
       if (Update.write(payload, length) != length) {
-        Logger::log(PSTR("Error during Update.write"));
-        m_fwState = "UPDATE ERROR";
+        Logger::log(ERROR_UPDATE_BEGIN);
+        m_fwState = FW_STATE_UPDATE_ERROR;
         return;
       }
 
@@ -915,25 +1135,25 @@ class ThingsBoardSized
       if (m_fwSize == sizeReceive) {
         md5.calculate();
         String md5Str = md5.toString();
-        char actual[24U + md5Str.length()];
-        snprintf_P(actual, sizeof(actual), PSTR("MD5 actual checksum: (%s)"), md5Str.c_str());
+        char actual[JSON_STRING_SIZE(strlen(MD5_ACTUAL)) + md5Str.length()];
+        snprintf_P(actual, sizeof(actual), MD5_ACTUAL, md5Str.c_str());
         Logger::log(actual);
-        char expected[26U + m_fwChecksum.length()];
-        snprintf_P(expected, sizeof(expected), PSTR("MD5 expected checksum: (%s)"), m_fwChecksum.c_str());
+        char expected[JSON_STRING_SIZE(strlen(MD5_EXPECTED)) + JSON_STRING_SIZE(strlen(m_fwChecksum))];
+        snprintf_P(expected, sizeof(expected), MD5_EXPECTED, m_fwChecksum);
         Logger::log(expected);
         // Check MD5
-        if (md5Str != m_fwChecksum) {
-          Logger::log(PSTR("Checksum verification failed !"));
+        if (strncmp(md5Str.c_str(), m_fwChecksum, md5Str.length()) != 0) {
+          Logger::log(CHKS_VER_FAILED);
 #if defined(ESP32)
           Update.abort();
 #endif
-          m_fwState = "CHECKSUM ERROR";
+          m_fwState = FW_STATE_CHKS_ERROR;
         }
         else {
-          Logger::log(PSTR("Checksum is OK !"));
+          Logger::log(CHKS_VER_SUCCESS);
           if (Update.end(true)) {
-            Logger::log(PSTR("Update Success !"));
-            m_fwState = "SUCCESS";
+            Logger::log(FW_UPDATE_SUCCESS);
+            m_fwState = SUCCESS;
           }
         }
       }
@@ -941,30 +1161,37 @@ class ThingsBoardSized
 #endif
 
     // Processes shared attribute update message
-    inline void process_shared_attribute_update_message(char* topic, uint8_t* payload, unsigned int length) {
+    inline void process_shared_attribute_update_message(char* topic, uint8_t* payload, uint32_t length) {
       StaticJsonDocument<JSON_OBJECT_SIZE(MaxFieldsAmt)> jsonBuffer;
       DeserializationError error = deserializeJson(jsonBuffer, payload, length);
       if (error) {
-        Logger::log(PSTR("Unable to de-serialize Shared attribute update request"));
+        Logger::log(UNABLE_TO_DE_SERIALIZE_ATT_UPDATE);
         return;
       }
       JsonObject data = jsonBuffer.template as<JsonObject>();
 
       if (data && (data.size() >= 1)) {
-        Logger::log(PSTR("Received shared attribute update request"));
-        if (data[PSTR("shared")]) {
-          data = data[PSTR("shared")];
+        Logger::log(RECEIVED_ATT_UPDATE);
+        if (data.containsKey(SHARED_KEY)) {
+          data = data[SHARED_KEY];
         }
-      } else {
-        Logger::log(PSTR("Shared attribute update key not found."));
+      }
+      else {
+        Logger::log(NOT_FOUND_ATT_UPDATE);
         return;
       }
 
       for (size_t i = 0; i < m_sharedAttributeUpdateCallbacks.size(); i++) {
+        char id_message[JSON_STRING_SIZE(strlen(ATT_CB_ID)) + detect_size(i)];
+        snprintf_P(id_message, sizeof(id_message), ATT_CB_ID, i);
+        Logger::log(id_message);
+
         if (m_sharedAttributeUpdateCallbacks.at(i).m_cb == nullptr) {
+          Logger::log(ATT_CB_IS_NULL);
           continue;
         }
         else if (m_sharedAttributeUpdateCallbacks.at(i).m_att.empty()) {
+          Logger::log(ATT_CB_NO_KEYS);
           // No specifc keys were subscribed so we call the callback anyway.
           m_sharedAttributeUpdateCallbacks.at(i).m_cb(data);
           continue;
@@ -974,12 +1201,16 @@ class ThingsBoardSized
         const char* requested_att;
         for (const char* att : m_sharedAttributeUpdateCallbacks.at(i).m_att) {
           if (att == nullptr) {
+            Logger::log(ATT_IS_NULL);
             continue;
           }
           // Check if the request contained any of our requested keys.
           containsKey = containsKey || data.containsKey(att);
           // Break early if the key was requested from this callback.
           if (containsKey) {
+            char contained_message[JSON_STRING_SIZE(strlen(ATT_IN_ARRAY)) + JSON_STRING_SIZE(strlen(att))];
+            snprintf_P(contained_message, sizeof(contained_message), ATT_IN_ARRAY, att);
+            Logger::log(contained_message);
             requested_att = att;
             break;
           }
@@ -988,12 +1219,13 @@ class ThingsBoardSized
         // This callback did not request any keys that were in this response,
         // therefore we continue with the next element in the loop.
         if (!containsKey || requested_att == nullptr) {
+          Logger::log(ATT_NO_CHANGE);
           continue;
         }
 
-        char message[53U + strlen(requested_att) + 1U];
-        snprintf_P(message, sizeof(message), PSTR("Calling subscribed callback for updated attribute (%s)"), requested_att);
-        Logger::log(message);
+        char calling_message[JSON_STRING_SIZE(strlen(CALLING_ATT_CB)) + JSON_STRING_SIZE(strlen(requested_att))];
+        snprintf_P(calling_message, sizeof(calling_message), CALLING_ATT_CB, requested_att);
+        Logger::log(calling_message);
         // Getting non-existing field from JSON should automatically
         // set JSONVariant to null
         m_sharedAttributeUpdateCallbacks.at(i).m_cb(data);
@@ -1001,61 +1233,43 @@ class ThingsBoardSized
     }
 
     // Processes shared attribute request message
-    inline void process_shared_attribute_request_message(char* topic, uint8_t* payload, unsigned int length) {
+    inline void process_shared_attribute_request_message(char* topic, uint8_t* payload, uint32_t length) {
       StaticJsonDocument<JSON_OBJECT_SIZE(MaxFieldsAmt)> jsonBuffer;
       DeserializationError error = deserializeJson(jsonBuffer, payload, length);
       if (error) {
-        Logger::log(PSTR("Unable to de-serialize Shared attribute request"));
+        Logger::log(UNABLE_TO_DE_SERIALIZE_ATT_REQUEST);
         return;
       }
       JsonObject data = jsonBuffer.template as<JsonObject>();
 
       if (data && (data.size() >= 1)) {
-        Logger::log(PSTR("Received shared attribute request"));
-        if (data[PSTR("shared")]) {
-          data = data[PSTR("shared")];
+        Logger::log(RECEIVED_ATT);
+        if (data.containsKey(SHARED_KEY)) {
+          data = data[SHARED_KEY];
         }
       } else {
-        Logger::log(PSTR("Shared attribute key not found."));
+        Logger::log(ATT_KEY_NOT_FOUND);
         return;
       }
 
-      // Save data for firmware update
-#if defined(ESP8266) || defined(ESP32)
-      if (data[PSTR("fw_title")]) {
-        m_fwTitle = data[PSTR("fw_title")].as<String>();
-      }
-      if (data[PSTR("fw_version")]) {
-        m_fwVersion = data[PSTR("fw_version")].as<String>();
-      }
-      if (data[PSTR("fw_checksum")]) {
-        m_fwChecksum = data[PSTR("fw_checksum")].as<String>();
-      }
-      if (data[PSTR("fw_checksum_algorithm")]) {
-        m_fwChecksumAlgorithm = data[PSTR("fw_checksum_algorithm")].as<String>();
-      }
-      if (data[PSTR("fw_size")]) {
-        m_fwSize = data[PSTR("fw_size")].as<int>();
-      }
-#endif
-
       std::string response = topic;
       // Remove the not needed part of the topic.
-      size_t index = strlen("v1/devices/me/attributes/response/");
+      size_t index = strlen(ATTRIBUTE_RESPONSE_TOPIC) + 1U;
       response = response.substr(index, response.length() - index);
       // convert the remaining text to an integer
       uint32_t response_id = atoi(response.c_str());
 
       for (size_t i = 0; i < m_sharedAttributeRequestCallbacks.size(); i++) {
         if (m_sharedAttributeRequestCallbacks.at(i).m_cb == nullptr) {
+          Logger::log(ATT_REQUEST_CB_IS_NULL);
           continue;
         }
         else if (m_sharedAttributeRequestCallbacks.at(i).m_request_id != response_id) {
           continue;
         }
 
-        char message[47U + detect_size(response_id)];
-        snprintf_P(message, sizeof(message), PSTR("Calling subscribed callback for response id (%u)"), response_id);
+        char message[JSON_STRING_SIZE(strlen(CALLING_REQUEST_ATT_CB)) + detect_size(response_id)];
+        snprintf_P(message, sizeof(message), CALLING_REQUEST_ATT_CB, response_id);
         Logger::log(message);
         // Getting non-existing field from JSON should automatically
         // set JSONVariant to null
@@ -1067,22 +1281,22 @@ class ThingsBoardSized
 
     // Processes provisioning response
 #if defined(ESP8266) || defined(ESP32) || defined(ARDUINO_AVR_MEGA)
-    inline void process_provisioning_response(char* topic, uint8_t* payload, unsigned int length) {
-      Logger::log(PSTR("Process provisioning response"));
+    inline void process_provisioning_response(char* topic, uint8_t* payload, uint32_t length) {
+      Logger::log(PROV_RESPONSE);
 
       StaticJsonDocument<JSON_OBJECT_SIZE(MaxFieldsAmt)> jsonBuffer;
       DeserializationError error = deserializeJson(jsonBuffer, payload, length);
       if (error) {
-        Logger::log(PSTR("Unable to de-serialize provision response"));
+        Logger::log(UNABLE_TO_DE_SERIALIZE_PROV_RESPONSE);
         return;
       }
 
       const JsonObject &data = jsonBuffer.template as<JsonObject>();
 
-      Logger::log(PSTR("Received provision response"));
+      Logger::log(RECEIVED_PROV_RESPONSE);
 
-      if (data[PSTR("status")] == "SUCCESS" && data[PSTR("credentialsType")] == "X509_CERTIFICATE") {
-        Logger::log(PSTR("Provision response contains X509_CERTIFICATE credentials, it is not supported yet."));
+      if (strncmp_P(SUCCESS, data[PROV_STATUS_KEY], strlen(SUCCESS)) == 0 && strncmp_P(PROV_CRED_TYPE_VALUE, data[PROV_CRED_TYPE_KEY], strlen(PROV_CRED_TYPE_VALUE)) == 0) {
+        Logger::log(X509_NOT_SUPPORTED);
         return;
       }
 
@@ -1094,29 +1308,17 @@ class ThingsBoardSized
 
     // Sends array of attributes or telemetry to ThingsBoard
     inline const bool sendDataArray(const Telemetry *data, size_t data_count, bool telemetry = true) {
-      if (MaxFieldsAmt < data_count) {
-        Logger::log(PSTR("too much JSON fields passed"));
-        return false;
-      }
-      char payload[PayloadSize];
-      {
-        StaticJsonDocument<JSON_OBJECT_SIZE(MaxFieldsAmt)> jsonBuffer;
-        JsonVariant object = jsonBuffer.template to<JsonVariant>();
+      StaticJsonDocument<JSON_OBJECT_SIZE(MaxFieldsAmt)> jsonBuffer;
+      JsonVariant object = jsonBuffer.template to<JsonVariant>();
 
-        for (size_t i = 0; i < data_count; ++i) {
-          if (data[i].serializeKeyval(object) == false) {
-            Logger::log(PSTR("unable to serialize data"));
-            return false;
-          }
-        }
-        if (JSON_STRING_SIZE(measureJson(jsonBuffer)) > PayloadSize) {
-          Logger::log(PSTR("too small buffer for JSON data"));
+      for (size_t i = 0; i < data_count; ++i) {
+        if (data[i].serializeKeyval(object) == false) {
+          Logger::log(UNABLE_TO_SERIALIZE);
           return false;
         }
-        serializeJson(object, payload, sizeof(payload));
       }
 
-      return telemetry ? sendTelemetryJson(payload) : sendAttributeJSON(payload);
+      return telemetry ? sendTelemetryJson(object) : sendAttributeJSON(object);
     }
 
     PubSubClient m_client; // PubSub MQTT client instance.
@@ -1127,37 +1329,37 @@ class ThingsBoardSized
 #if defined(ESP8266) || defined(ESP32) || defined(ARDUINO_AVR_MEGA)
     Provision_Callback m_provisionCallback; // Provision response callback
 #endif
-    unsigned int m_requestId;
+    uint32_t m_requestId; // Allows nearly 4.3 million requests before wrapping back to 0.
 
 #if defined(ESP8266) || defined(ESP32)
     // For Firmware Update
-    String m_fwVersion;
-    String m_fwState;
-    String m_fwTitle;
-    String m_fwChecksum;
-    String m_fwChecksumAlgorithm;
-    unsigned int m_fwSize;
-    int m_fwChunkReceive;
+    const char* m_currFwTitle;
+    const char* m_currFwVersion;
+    const char* m_fwState;
+    uint16_t m_fwSize;
+    const char* m_fwChecksum;
+    const std::function<void(const bool&)> m_fwUpdatedCallback;
+    uint16_t m_fwChunkReceive;
 #endif
 
     // The callback for when a PUBLISH message is received from the server.
-    inline void on_message(char* topic, uint8_t* payload, unsigned int length) {
-      char message[35U + strlen(topic)];
-      snprintf_P(message, sizeof(message), PSTR("Callback on_message from topic: (%s)"), topic);
+    inline void on_message(char* topic, uint8_t* payload, uint32_t length) {
+      char message[JSON_STRING_SIZE(strlen(CB_ON_MESSAGE)) + JSON_STRING_SIZE(strlen(topic))];
+      snprintf_P(message, sizeof(message), CB_ON_MESSAGE, topic);
       Logger::log(message);
 
-      if (strncmp("v1/devices/me/rpc", topic, strlen("v1/devices/me/rpc")) == 0) {
+      if (strncmp_P(RPC_TOPIC, topic, strlen(RPC_TOPIC)) == 0) {
         process_rpc_message(topic, payload, length);
-      } else if (strncmp("v1/devices/me/attributes/response", topic, strlen("v1/devices/me/attributes/response")) == 0) {
+      } else if (strncmp_P(ATTRIBUTE_RESPONSE_TOPIC, topic, strlen(ATTRIBUTE_RESPONSE_TOPIC)) == 0) {
         process_shared_attribute_request_message(topic, payload, length);
-      } else if (strncmp("v1/devices/me/attributes", topic, strlen("v1/devices/me/attributes")) == 0) {
+      } else if (strncmp_P(ATTRIBUTE_TOPIC, topic, strlen(ATTRIBUTE_TOPIC)) == 0) {
         process_shared_attribute_update_message(topic, payload, length);
       } else {
-        if (strncmp("/provision/response", topic, strlen("/provision/response")) == 0) {
+        if (strncmp_P(PROV_RESPONSE_TOPIC, topic, strlen(PROV_RESPONSE_TOPIC)) == 0) {
 #if defined(ESP8266) || defined(ESP32) || defined(ARDUINO_AVR_MEGA)
           process_provisioning_response(topic, payload, length);
 #endif
-        } else if (strncmp("v2/fw/response", topic, strlen("v2/fw/response")) == 0) {
+        } else if (strncmp_P(FIRMWARE_RESPONSE_TOPIC, topic, strlen(FIRMWARE_RESPONSE_TOPIC)) == 0) {
 #if defined(ESP8266) || defined(ESP32)
           process_firmware_response(topic, payload, length);
 #endif
@@ -1227,16 +1429,16 @@ class ThingsBoardHttpSized
 
       if (!m_client.connected()) {
         if (!m_client.connect(m_host, m_port)) {
-          Logger::log(PSTR("connect to server failed"));
+          Logger::log(CONNECT_FAILED);
           return false;
         }
       }
 
       bool rc = true;
 
-      char path[19U + strlen(m_token)];
-      snprintf_P(path, sizeof(path), PSTR("/api/v1/%s/telemetry"), m_token);
-      if (!m_client.post(path, "application/json", json) ||
+      char path[JSON_STRING_SIZE(strlen(HTTP_TELEMETRY_TOPIC)) + JSON_STRING_SIZE(strlen(m_token))];
+      snprintf_P(path, sizeof(path), HTTP_TELEMETRY_TOPIC, m_token);
+      if (!m_client.post(path, HTTP_POST_PATH, json) ||
           (m_client.responseStatusCode() != HTTP_SUCCESS)) {
         rc = false;
       }
@@ -1281,16 +1483,16 @@ class ThingsBoardHttpSized
 
       if (!m_client.connected()) {
         if (!m_client.connect(m_host, m_port)) {
-          Logger::log(PSTR("connect to server failed"));
+          Logger::log(CONNECT_FAILED);
           return false;
         }
       }
 
       bool rc = true;
 
-      char path[19U + strlen(m_token)];
-      snprintf_P(path, sizeof(path), PSTR("/api/v1/%s/attributes"), m_token);
-      if (!m_client.post(path, "application/json", json)
+      char path[JSON_STRING_SIZE(strlen(HTTP_ATTRIBUTES_TOPIC)) + JSON_STRING_SIZE(strlen(m_token))];
+      snprintf_P(path, sizeof(path), HTTP_ATTRIBUTES_TOPIC, m_token);
+      if (!m_client.post(path, HTTP_POST_PATH, json)
           || (m_client.responseStatusCode() != HTTP_SUCCESS)) {
         rc = false;
       }
@@ -1302,30 +1504,17 @@ class ThingsBoardHttpSized
   private:
     // Sends array of attributes or telemetry to ThingsBoard
     inline const bool sendDataArray(const Telemetry *data, size_t data_count, bool telemetry = true) {
-      if (MaxFieldsAmt < data_count) {
-        Logger::log(PSTR("too much JSON fields passed"));
-        return false;
-      }
-      char payload[PayloadSize];
-      {
-        StaticJsonDocument<JSON_OBJECT_SIZE(MaxFieldsAmt)> jsonBuffer;
-        JsonVariant object = jsonBuffer.template to<JsonVariant>();
+      StaticJsonDocument<JSON_OBJECT_SIZE(MaxFieldsAmt)> jsonBuffer;
+      JsonVariant object = jsonBuffer.template to<JsonVariant>();
 
-        for (size_t i = 0; i < data_count; ++i) {
-          if (data[i].serializeKeyval(object) == false) {
-            Logger::log(PSTR("unable to serialize data"));
-            return false;
-          }
-        }
-
-        if (JSON_STRING_SIZE(measureJson(jsonBuffer)) > PayloadSize) {
-          Logger::log(PSTR("too small buffer for JSON data"));
+      for (size_t i = 0; i < data_count; ++i) {
+        if (data[i].serializeKeyval(object) == false) {
+          Logger::log(UNABLE_TO_SERIALIZE);
           return false;
         }
-        serializeJson(object, payload, sizeof(payload));
       }
 
-      return telemetry ? sendTelemetryJson(payload) : sendAttributeJSON(payload);
+      return telemetry ? sendTelemetryJson(object) : sendAttributeJSON(object);
     }
 
     // Sends single key-value in a generic way.
@@ -1333,23 +1522,14 @@ class ThingsBoardHttpSized
     inline const bool sendKeyval(const char *key, T value, bool telemetry = true) {
       Telemetry t(key, value);
 
-      char payload[PayloadSize];
-      {
-        Telemetry t(key, value);
-        StaticJsonDocument<JSON_OBJECT_SIZE(1)> jsonBuffer;
-        JsonVariant object = jsonBuffer.template to<JsonVariant>();
-        if (t.serializeKeyval(object) == false) {
-          Logger::log(PSTR("unable to serialize data"));
-          return false;
-        }
-
-        if (JSON_STRING_SIZE(measureJson(jsonBuffer)) > PayloadSize) {
-          Logger::log(PSTR("too small buffer for JSON data"));
-          return false;
-        }
-        serializeJson(object, payload, sizeof(payload));
+      StaticJsonDocument<JSON_OBJECT_SIZE(1)> jsonBuffer;
+      JsonVariant object = jsonBuffer.template to<JsonVariant>();
+      if (t.serializeKeyval(object) == false) {
+        Logger::log(UNABLE_TO_SERIALIZE);
+        return false;
       }
-      return telemetry ? sendTelemetryJson(payload) : sendAttributeJSON(payload);
+
+      return telemetry ? sendTelemetryJson(object) : sendAttributeJSON(object);
     }
 
     HttpClient m_client;

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -256,8 +256,8 @@ class ThingsBoardSized
       StaticJsonDocument<JSON_OBJECT_SIZE(1)> requestBuffer;
       JsonObject resp_obj = requestBuffer.to<JsonObject>();
 
-      resp_obj[F("secretKey")] = secretKey;
-      resp_obj[F("durationMs")] = durationMs;
+      resp_obj["secretKey"] = secretKey;
+      resp_obj["durationMs"] = durationMs;
 
       uint8_t objectSize = measureJson(requestBuffer) + 1;
       char responsePayload[objectSize];
@@ -272,9 +272,9 @@ class ThingsBoardSized
       StaticJsonDocument<JSON_OBJECT_SIZE(3)> requestBuffer;
       JsonObject requestObject = requestBuffer.to<JsonObject>();
 
-      requestObject[F("deviceName")] = deviceName;
-      requestObject[F("provisionDeviceKey")] = provisionDeviceKey;
-      requestObject[F("provisionDeviceSecret")] = provisionDeviceSecret;
+      requestObject["deviceName"] = deviceName;
+      requestObject["provisionDeviceKey"] = provisionDeviceKey;
+      requestObject["provisionDeviceSecret"] = provisionDeviceSecret;
 
       uint8_t objectSize = measureJson(requestBuffer) + 1;
       char requestPayload[objectSize];
@@ -540,8 +540,8 @@ class ThingsBoardSized
       StaticJsonDocument<JSON_OBJECT_SIZE(2)> currentFirmwareInfo;
       JsonObject currentFirmwareInfoObject = currentFirmwareInfo.to<JsonObject>();
 
-      currentFirmwareInfoObject[F("current_fw_title")] = currFwTitle;
-      currentFirmwareInfoObject[F("current_fw_version")] = currFwVersion;
+      currentFirmwareInfoObject["current_fw_title"] = currFwTitle;
+      currentFirmwareInfoObject["current_fw_version"] = currFwVersion;
 
       int objectSize = measureJson(currentFirmwareInfo) + 1;
       char buffer[objectSize];
@@ -555,7 +555,7 @@ class ThingsBoardSized
       StaticJsonDocument<JSON_OBJECT_SIZE(1)> currentFirmwareState;
       JsonObject currentFirmwareStateObject = currentFirmwareState.to<JsonObject>();
 
-      currentFirmwareStateObject[F("current_fw_state")] = currFwState;
+      currentFirmwareStateObject["current_fw_state"] = currFwState;
 
       int objectSize = measureJson(currentFirmwareState) + 1;
       char buffer[objectSize];
@@ -603,7 +603,7 @@ class ThingsBoardSized
         return false;
       }
 
-      requestObject[F("sharedKeys")] = sharedKeys.c_str();
+      requestObject["sharedKeys"] = sharedKeys.c_str();
       int objectSize = measureJson(requestBuffer) + 1;
       char buffer[objectSize];
       serializeJson(requestObject, buffer, objectSize);
@@ -719,8 +719,8 @@ class ThingsBoardSized
           return;
         }
         const JsonObject &data = jsonBuffer.template as<JsonObject>();
-        const char *methodName = data[F("method")];
-        const char *params = data[F("params")];
+        const char *methodName = data["method"];
+        const char *params = data["params"];
 
         if (methodName) {
           Logger::log("received RPC:");
@@ -750,8 +750,8 @@ class ThingsBoardSized
           //if failed to de-serialize params then send JsonObject instead
           if (err_param) {
             Logger::log("params:");
-            Logger::log(data[F("params")].as<String>().c_str());
-            r = callback.m_cb(data[F("params")]);
+            Logger::log(data["params"].as<String>().c_str());
+            r = callback.m_cb(data["params"]);
           } else {
             Logger::log("params:");
             Logger::log(params);
@@ -859,8 +859,8 @@ class ThingsBoardSized
 
       if (data && (data.size() >= 1)) {
         Logger::log("Received shared attribute update request");
-        if (data[F("shared")]) {
-          data = data[F("shared")];
+        if (data["shared"]) {
+          data = data["shared"];
         }
       } else {
         Logger::log("Shared attribute update key not found.");
@@ -869,20 +869,20 @@ class ThingsBoardSized
 
       // Save data for firmware update
 #if defined(ESP8266) || defined(ESP32)
-      if (data[F("fw_title")]) {
-        m_fwTitle = data[F("fw_title")].as<String>();
+      if (data["fw_title"]) {
+        m_fwTitle = data["fw_title"].as<String>();
       }
-      if (data[F("fw_version")]) {
-        m_fwVersion = data[F("fw_version")].as<String>();
+      if (data["fw_version"]) {
+        m_fwVersion = data["fw_version"].as<String>();
       }
-      if (data[F("fw_checksum")]) {
-        m_fwChecksum = data[F("fw_checksum")].as<String>();
+      if (data["fw_checksum"]) {
+        m_fwChecksum = data["fw_checksum"].as<String>();
       }
-      if (data[F("fw_checksum_algorithm")]) {
-        m_fwChecksumAlgorithm = data[F("fw_checksum_algorithm")].as<String>();
+      if (data["fw_checksum_algorithm"]) {
+        m_fwChecksumAlgorithm = data["fw_checksum_algorithm"].as<String>();
       }
-      if (data[F("fw_size")]) {
-        m_fwSize = data[F("fw_size")].as<int>();
+      if (data["fw_size"]) {
+        m_fwSize = data["fw_size"].as<int>();
       }
 #endif
 
@@ -920,7 +920,7 @@ class ThingsBoardSized
 
       Logger::log("Received provision response");
 
-      if (data[F("status")] == "SUCCESS" && data[F("credentialsType")] == "X509_CERTIFICATE") {
+      if (data["status"] == "SUCCESS" && data["credentialsType"] == "X509_CERTIFICATE") {
         Logger::log("Provision response contains X509_CERTIFICATE credentials, it is not supported yet.");
         return;
       }

--- a/src/ThingsBoardDefaultLogger.cpp
+++ b/src/ThingsBoardDefaultLogger.cpp
@@ -1,6 +1,9 @@
 // Header include.
 #include "ThingsBoardDefaultLogger.h"
 
+// Library include.
+#include "HardwareSerial.h"
+
 void ThingsBoardDefaultLogger::log(const char *msg) {
   Serial.print(F("[TB] "));
   Serial.println(msg);

--- a/src/ThingsBoardDefaultLogger.cpp
+++ b/src/ThingsBoardDefaultLogger.cpp
@@ -1,0 +1,7 @@
+// Header include.
+#include "ThingsBoardDefaultLogger.h"
+
+void ThingsBoardDefaultLogger::log(const char *msg) {
+  Serial.print(F("[TB] "));
+  Serial.println(msg);
+}

--- a/src/ThingsBoardDefaultLogger.h
+++ b/src/ThingsBoardDefaultLogger.h
@@ -1,0 +1,10 @@
+#ifndef THINGSBOARD_DEFAULT_LOGGER
+#define THINGSBOARD_DEFAULT_LOGGER
+
+class ThingsBoardDefaultLogger {
+public:
+    // ThingsBoardDefaultLogger log method.
+    static void log(const char* msg);
+};
+
+#endif // THINGSBOARD_DEFAULT_LOGGER


### PR DESCRIPTION
The code has been tested with the ESP32. Testing with ESP8266 would be required, before integrating.

Changes include switching subscribe c-style arrays to ```std::vector``` with a fixed size (MaxFieldsAmt) that is reserved and checked when subscribing. #27

Removed not needed ```#include``` statements. #66

Additionaly all callbacks have been changed to be ```std::function``` resulting in being able to use ```std::bind(&ExampleClass::example_callback, this, std::placeholders::_1)``` to bind private class member methods to the function pointer instead on having to rely on ```static``` methods.

The ThingsBoardInstance was removed and replaced with a private member method callback that is subscribed without using a static method --> meaning you can additionaly subscribe to multiple topics. #63

The Client buffersize gets set by the given template PayloadSize as well. #39

The Shared Attribute Request now allows multiple keys and actually calls a callback you can pass as an argument. #45

Removed the setting of private members in the constructor fixing weird behaviour when using 2 ThingsBoard instances (Provision and Client). #42

Moved constant strings into flash and removed String concatenation to decrease heap fragmentation.

Added the possiblity to enable quality of service for MQTT communication.
