### PR TITLE
Fix bugs introduced by version 0.7

### DIFF
--- a/examples/0002-arduino_rpc/0002-arduino_rpc.ino
+++ b/examples/0002-arduino_rpc/0002-arduino_rpc.ino
@@ -122,7 +122,7 @@ void loop() {
     // Perform a subscription. All consequent data processing will happen in
     // processTemperatureChange() and processSwitchChange() functions,
     // as denoted by callbacks vector.
-    if (!tb.RPC_Subscribe(callbacks)) {
+    if (!tb.RPC_Subscribe(callbacks.cbegin(), callbacks.cend())) {
       Serial.println("Failed to subscribe for RPC");
       return;
     }

--- a/library.json
+++ b/library.json
@@ -6,7 +6,7 @@
         "type": "git",
         "url": "https://github.com/thingsboard/ThingsBoard-Arduino-MQTT-SDK"
     },
-    "version": "0.6",
+    "version": "0.7",
     "examples": "examples/*/*.ino",
     "frameworks": "arduino"
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ThingsBoard
-version=0.6
+version=0.7
 author=ThingsBoard Team
 maintainer=ThingsBoard Team
 sentence=ThingsBoard library for Arduino.

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -12,16 +12,25 @@
 #include <ArduinoHttpClient.h>
 #endif
 
-#if defined(ESP8266)
-#include <Updater.h>
-#elif defined(ESP32)
-#include <Update.h>
-#endif
-
 #include <PubSubClient.h>
 #include <ArduinoJson.h>
 #include <vector>
 #include <array>
+#include <functional>
+#include <pgmspace.h>
+
+#if defined(ESP8266)
+#include <Updater.h>
+// Add defines used that or not included in the pgm header.
+#ifndef snprintf_P
+#define snprintf_P    snprintf
+#endif // snprintf_P
+#ifndef vsnprintf_P
+#define vsnprintf_P   vsnprintf
+#endif // vsnprintf_P
+#elif defined(ESP32)
+#include <Update.h>
+#endif
 
 // Local includes.
 #include "ThingsBoardDefaultLogger.h"

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -103,7 +103,6 @@ constexpr char ATT_KEY_NOT_FOUND[] = PSTR("Shared attribute key not found");
 constexpr char ATT_REQUEST_CB_IS_NULL[] = PSTR("Shared attribute request callback is NULL");
 constexpr char CALLING_REQUEST_ATT_CB[] = PSTR("Calling subscribed callback for response id (%u)");
 constexpr char TOO_MANY_JSON_FIELDS[] = PSTR("Too many JSON fields passed (%u), increase MaxFieldsAmt (%u) accordingly");
-constexpr char TOO_BIG_JSON_TEXT[] = PSTR("Too big of a JSON passed (%u), increase PayloadSize (%u) accordingly");
 constexpr char CB_ON_MESSAGE[] = PSTR("Callback on_message from topic: (%s)");
 constexpr char CONNECT_FAILED[] = PSTR("Connecting to server failed");
 
@@ -533,7 +532,7 @@ class ThingsBoardSized
       }
 
       const uint32_t json_size = JSON_STRING_SIZE(strlen(json));
-      if (json_size > PayloadSize) {
+      if (PayloadSize < json_size) {
         char message[detect_size(INVALID_BUFFER_SIZE, PayloadSize, json_size)];
         snprintf_P(message, sizeof(message), INVALID_BUFFER_SIZE, PayloadSize, json_size);
         Logger::log(message);
@@ -544,16 +543,10 @@ class ThingsBoardSized
 
     // Sends custom JSON telemetry JsonObject to the ThingsBoard.
     inline const bool sendTelemetryJson(const JsonObject& jsonObject, const uint32_t& jsonSize) {
-      const uint32_t json_object_size = jsonObject.size();
-      if (MaxFieldsAmt < json_object_size) {
-        char message[detect_size(TOO_MANY_JSON_FIELDS, json_object_size, MaxFieldsAmt)];
-        snprintf_P(message, sizeof(message), TOO_MANY_JSON_FIELDS, json_object_size, MaxFieldsAmt);
-        Logger::log(message);
-        return false;
-      }
-      else if (PayloadSize < jsonSize) {
-        char message[detect_size(TOO_BIG_JSON_TEXT, jsonSize, PayloadSize)];
-        snprintf_P(message, sizeof(message), TOO_BIG_JSON_TEXT, jsonSize, PayloadSize);
+      const uint32_t jsonObjectSize = jsonObject.size();
+      if (MaxFieldsAmt < jsonObjectSize) {
+        char message[detect_size(TOO_MANY_JSON_FIELDS, jsonObjectSize, MaxFieldsAmt)];
+        snprintf_P(message, sizeof(message), TOO_MANY_JSON_FIELDS, jsonObjectSize, MaxFieldsAmt);
         Logger::log(message);
         return false;
       }
@@ -603,7 +596,7 @@ class ThingsBoardSized
       }
 
       const uint32_t json_size = JSON_STRING_SIZE(strlen(json));
-      if (json_size > PayloadSize) {
+      if (PayloadSize < json_size) {
         char message[detect_size(INVALID_BUFFER_SIZE, PayloadSize, json_size)];
         snprintf_P(message, sizeof(message), INVALID_BUFFER_SIZE, PayloadSize, json_size);
         Logger::log(message);
@@ -614,16 +607,10 @@ class ThingsBoardSized
 
     // Sends custom JsonObject with attributes to the ThingsBoard.
     inline const bool sendAttributeJSON(const JsonObject& jsonObject, const uint32_t& jsonSize) {
-      const uint32_t json_object_size = jsonObject.size();
-      if (MaxFieldsAmt < json_object_size) {
-        char message[detect_size(TOO_MANY_JSON_FIELDS, json_object_size, MaxFieldsAmt)];
-        snprintf_P(message, sizeof(message), TOO_MANY_JSON_FIELDS, json_object_size, MaxFieldsAmt);
-        Logger::log(message);
-        return false;
-      }
-      else if (PayloadSize < jsonSize) {
-        char message[detect_size(TOO_BIG_JSON_TEXT, jsonSize, PayloadSize)];
-        snprintf_P(message, sizeof(message), TOO_BIG_JSON_TEXT, jsonSize, PayloadSize);
+      const uint32_t jsonObjectSize = jsonObject.size();
+      if (MaxFieldsAmt < jsonObjectSize) {
+        char message[detect_size(TOO_MANY_JSON_FIELDS, jsonObjectSize, MaxFieldsAmt)];
+        snprintf_P(message, sizeof(message), TOO_MANY_JSON_FIELDS, jsonObjectSize, MaxFieldsAmt);
         Logger::log(message);
         return false;
       }
@@ -1116,7 +1103,7 @@ class ThingsBoardSized
       }
 
       const uint32_t json_size = JSON_STRING_SIZE(measureJson(respBuffer));
-      if (json_size > PayloadSize) {
+      if (PayloadSize < json_size) {
         char message[detect_size(INVALID_BUFFER_SIZE, PayloadSize, json_size)];
         snprintf_P(message, sizeof(message), INVALID_BUFFER_SIZE, PayloadSize, json_size);
         Logger::log(message);

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -384,6 +384,9 @@ class ThingsBoardSized
       : m_client()
       , m_requestId(0)
       , m_qos(enableQoS)
+#if defined(ESP8266) || defined(ESP32)
+      , m_fwResponseCallback(std::bind(&ThingsBoardSized::Firmware_Shared_Attribute_Received, this, std::placeholders::_1))
+#endif
     {
       reserve_callback_size();
       setClient(client);
@@ -394,6 +397,9 @@ class ThingsBoardSized
       : m_client()
       , m_requestId(0)
       , m_qos(false)
+#if defined(ESP8266) || defined(ESP32)
+      , m_fwResponseCallback(std::bind(&ThingsBoardSized::Firmware_Shared_Attribute_Received, this, std::placeholders::_1))
+#endif
     {
       reserve_callback_size();
     }
@@ -728,8 +734,7 @@ class ThingsBoardSized
 
       // Request the firmware informations
       const std::array<const char*, 5U> fwSharedKeys {FW_CHKS_KEY, FW_CHKS_ALGO_KEY, FW_SIZE_KEY, FW_TITLE_KEY, FW_VER_KEY};
-      Shared_Attribute_Request_Callback callback(std::bind(&ThingsBoardSized::Firmware_Shared_Attribute_Received, this, std::placeholders::_1));
-      return Shared_Attributes_Request(fwSharedKeys.cbegin(), fwSharedKeys.cend(), callback);
+      return Shared_Attributes_Request(fwSharedKeys.cbegin(), fwSharedKeys.cend(), m_fwResponseCallback);
     }
 
     inline const bool Firmware_Send_FW_Info(const char* currFwTitle, const char* currFwVersion) {
@@ -1414,6 +1419,7 @@ class ThingsBoardSized
     uint16_t m_fwSize;
     const char* m_fwChecksum;
     std::function<void(const bool&)> m_fwUpdatedCallback;
+    Shared_Attribute_Request_Callback m_fwResponseCallback;
     uint16_t m_fwChunkReceive;
 #endif
 

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -567,6 +567,20 @@ class ThingsBoardSized
       return sendTelemetryJson(json);
     }
 
+    // Sends custom JSON telemetry JsonVariant to the ThingsBoard.
+    inline const bool sendTelemetryJson(const JsonVariant& jsonVariant, const uint32_t& jsonSize) {
+      const uint32_t jsonVariantSize = jsonVariant.size();
+      if (MaxFieldsAmt < jsonVariantSize) {
+        char message[detect_size(TOO_MANY_JSON_FIELDS, jsonVariantSize, MaxFieldsAmt)];
+        snprintf_P(message, sizeof(message), TOO_MANY_JSON_FIELDS, jsonVariantSize, MaxFieldsAmt);
+        Logger::log(message);
+        return false;
+      }
+      char json[jsonSize];
+      serializeJson(jsonVariant, json, jsonSize);
+      return sendTelemetryJson(json);
+    }
+
     //----------------------------------------------------------------------------
     // Attribute API
 
@@ -629,6 +643,20 @@ class ThingsBoardSized
       char json[jsonSize];
       serializeJson(jsonObject, json, jsonSize);
       return sendAttributeJSON(json);
+    }
+
+    // Sends custom JsonVariant with attributes to the ThingsBoard.
+    inline const bool sendAttributeJSON(const JsonVariant& jsonVariant, const uint32_t& jsonSize) {
+      const uint32_t jsonVariantSize = jsonVariant.size();
+      if (MaxFieldsAmt < jsonVariantSize) {
+        char message[detect_size(TOO_MANY_JSON_FIELDS, jsonVariantSize, MaxFieldsAmt)];
+        snprintf_P(message, sizeof(message), TOO_MANY_JSON_FIELDS, jsonVariantSize, MaxFieldsAmt);
+        Logger::log(message);
+        return false;
+      }
+      char json[jsonSize];
+      serializeJson(jsonVariant, json, jsonSize);
+      return sendTelemetryJson(json);
     }
 
     //----------------------------------------------------------------------------

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -7,6 +7,7 @@
 #ifndef ThingsBoard_h
 #define ThingsBoard_h
 
+// Library includes.
 #if !defined(ESP8266) && !defined(ESP32)
 #include <ArduinoHttpClient.h>
 #endif
@@ -20,6 +21,7 @@
 #include <PubSubClient.h>
 #include <ArduinoJson.h>
 #include <vector>
+#include <array>
 
 // Local includes.
 #include "ThingsBoardDefaultLogger.h"
@@ -682,17 +684,15 @@ class ThingsBoardSized
         return false;
       }
 
-      // Request the firmware informations
-      const std::array<const char*, 5U> fwSharedKeys {FW_CHKS_KEY, FW_CHKS_ALGO_KEY, FW_SIZE_KEY, FW_TITLE_KEY, FW_VER_KEY};
-      if (!Shared_Attributes_Request(fwSharedKeys.cbegin(), fwSharedKeys.cend(), Shared_Attribute_Request_Callback(std::bind(&ThingsBoardSized::Firmware_Shared_Attribute_Received, this, std::placeholders::_1)))) {
-        return false;
-      }
-
       // Set private members needed for update.
       m_currFwTitle = currFwTitle;
       m_currFwVersion = currFwVersion;
       m_fwUpdatedCallback = updatedCallback;
-      return true;
+
+      // Request the firmware informations
+      const std::array<const char*, 5U> fwSharedKeys {FW_CHKS_KEY, FW_CHKS_ALGO_KEY, FW_SIZE_KEY, FW_TITLE_KEY, FW_VER_KEY};
+      Shared_Attribute_Request_Callback callback(std::bind(&ThingsBoardSized::Firmware_Shared_Attribute_Received, this, std::placeholders::_1));
+      return Shared_Attributes_Request(fwSharedKeys.cbegin(), fwSharedKeys.cend(), callback);
     }
 
     inline const bool Firmware_Send_FW_Info(const char* currFwTitle, const char* currFwVersion) {
@@ -1037,7 +1037,7 @@ class ThingsBoardSized
         return false;
       }
 
-      return telemetry ? sendTelemetryJson(object, JSON_STRING_SIZE(measureJson(object)) : sendAttributeJSON(object, JSON_STRING_SIZE(measureJson(object));
+      return telemetry ? sendTelemetryJson(object, JSON_STRING_SIZE(measureJson(object))) : sendAttributeJSON(object, JSON_STRING_SIZE(measureJson(object)));
     }
 
     // Processes RPC message
@@ -1355,7 +1355,7 @@ class ThingsBoardSized
         }
       }
 
-      return telemetry ? sendTelemetryJson(object, JSON_STRING_SIZE(measureJson(object)) : sendAttributeJSON(object, JSON_STRING_SIZE(measureJson(object));
+      return telemetry ? sendTelemetryJson(object, JSON_STRING_SIZE(measureJson(object))) : sendAttributeJSON(object, JSON_STRING_SIZE(measureJson(object)));
     }
 
     PubSubClient m_client; // PubSub MQTT client instance.
@@ -1376,7 +1376,7 @@ class ThingsBoardSized
     const char* m_fwState;
     uint16_t m_fwSize;
     const char* m_fwChecksum;
-    const std::function<void(const bool&)> m_fwUpdatedCallback;
+    std::function<void(const bool&)> m_fwUpdatedCallback;
     uint16_t m_fwChunkReceive;
 #endif
 
@@ -1552,7 +1552,7 @@ class ThingsBoardHttpSized
         }
       }
 
-      return telemetry ? sendTelemetryJson(object, JSON_STRING_SIZE(measureJson(object)) : sendAttributeJSON(object, JSON_STRING_SIZE(measureJson(object));
+      return telemetry ? sendTelemetryJson(object, JSON_STRING_SIZE(measureJson(object))) : sendAttributeJSON(object, JSON_STRING_SIZE(measureJson(object)));
     }
 
     // Sends single key-value in a generic way.
@@ -1567,7 +1567,7 @@ class ThingsBoardHttpSized
         return false;
       }
 
-      return telemetry ? sendTelemetryJson(object, JSON_STRING_SIZE(measureJson(object)) : sendAttributeJSON(object, JSON_STRING_SIZE(measureJson(object));
+      return telemetry ? sendTelemetryJson(object, JSON_STRING_SIZE(measureJson(object))) : sendAttributeJSON(object, JSON_STRING_SIZE(measureJson(object)));
     }
 
     HttpClient m_client;


### PR DESCRIPTION
Fixed #84, #83, #81, #74, #82 and added an attempt to fix #73. The ESP8266 should atleast compile now, but would definetly be good to check with a real ESP8266 test project.

The issues have been fixed via. the adding of methods to support directly sending `JsonVariant` as well for both `Attributes` and `Telemetry`.

Additionaly the ESP8266 does not support the methods `vsnprintf_P` and `snprintf_P` therefore an include has been added, so that they point to `vsnprintf` and `snprintf` if they have not been defined in the `pgmspace.h` header.

The version numbers has been bumped to 0.7 this is to ensure that it is possible to switch to the old version if needed.

Furthermore the RPC example has been updated to accurately reflect the current code and the `Start_Firmware_Update` has fixed how it passes the callback method to ensure it gets actually called and compiles.
