### PR TITLE
RP2040 support added

### DIFF
--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -8,6 +8,7 @@
 #define ThingsBoard_h
 
 // Library includes.
+#include <stdarg.h>
 #include <PubSubClient.h>
 
 #if defined(ESP8266)
@@ -15,6 +16,14 @@
 #elif defined(ESP32)
 #include <Update.h>
 #endif
+
+// Definition for not defined function (RP2040)
+#ifndef snprintf_P
+#define snprintf_P    snprintf
+#endif // snprintf_P
+#ifndef vsnprintf_P
+#define vsnprintf_P   vsnprintf
+#endif // vsnprintf_P
 
 // Local includes.
 #include "Configuration.h"

--- a/src/ThingsBoardDefaultLogger.cpp
+++ b/src/ThingsBoardDefaultLogger.cpp
@@ -2,6 +2,7 @@
 #include <ThingsBoardDefaultLogger.h>
 
 // Library include.
+#include <Arduino.h>
 #include <HardwareSerial.h>
 
 void ThingsBoardDefaultLogger::log(const char *msg) {


### PR DESCRIPTION
Added support for RP2040 chip (tested on Arduino Nano Connect (RP2040)).
Requires fix for pubsubclient (for callbacks) - https://github.com/knolleary/pubsubclient/pull/993 

Hi, @MathewHDYT, how do you think, how do we can pass this point? (I mean workaround for this issue, until fix will be merged)