### PR TITLE
Fixed workflow

### DIFF
--- a/.github/workflows/arduino-compile.yml
+++ b/.github/workflows/arduino-compile.yml
@@ -24,7 +24,7 @@ jobs:
       LIBRARIES: |
         # Install the additionally needed dependency from the respository
         - source-path: ./
-        - name: PubSubClient
+        - name: TBPubSubClient
         - name: ArduinoHttpClient
         - name: ArduinoJson
         - name: WiFiEsp

--- a/.github/workflows/esp32-compile.yml
+++ b/.github/workflows/esp32-compile.yml
@@ -24,7 +24,7 @@ jobs:
       LIBRARIES: |
         # Install the additionally needed dependency from the respository
         - source-path: ./
-        - name: PubSubClient
+        - name: TBPubSubClient
         - name: ArduinoHttpClient
         - name: ArduinoJson
       SKETCHES_REPORTS_PATH: sketches-reports

--- a/.github/workflows/esp8266-compile.yml
+++ b/.github/workflows/esp8266-compile.yml
@@ -24,7 +24,7 @@ jobs:
       LIBRARIES: |
         # Install the additionally needed dependency from the respository
         - source-path: ./
-        - name: PubSubClient
+        - name: TBPubSubClient
         - name: ArduinoHttpClient
         - name: ArduinoJson
         - name: Seeed_Arduino_mbedtls

--- a/library.json
+++ b/library.json
@@ -11,7 +11,7 @@
         "https://github.com/thingsboard/pubsubclient.git": "^2.9",
         "arduino-libraries/ArduinoHttpClient" : "^0.4.0"
     },
-    "version": "0.9.4",
+    "version": "0.9.5",
     "examples": "examples/*/*.ino",
     "frameworks": "arduino"
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ThingsBoard
-version=0.9.4
+version=0.9.5
 author=ThingsBoard Team
 maintainer=ThingsBoard Team
 sentence=ThingsBoard library for Arduino.

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -36,10 +36,12 @@
 #      ifndef THINGSBOARD_ENABLE_PROGMEM
 #        define THINGSBOARD_ENABLE_PROGMEM 1
 #      endif
+#    else
+#      ifndef THINGSBOARD_ENABLE_PROGMEM
+#        define THINGSBOARD_ENABLE_PROGMEM 0
+#      endif
 #    endif
-#  endif
-
-#  ifndef THINGSBOARD_ENABLE_PROGMEM
+#  else
 #    define THINGSBOARD_ENABLE_PROGMEM 0
 #  endif
 

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -31,15 +31,6 @@
 #include "Provision_Callback.h"
 #include "OTA_Update_Callback.h"
 
-#if !THINGSBOARD_ENABLE_PROGMEM
-#ifndef snprintf_P 
-#define snprintf_P snprintf
-#endif // snprintf_P
-#ifndef vsnprintf_P 
-#define vsnprintf_P vsnprintf
-#endif // vsnprintf_P
-#endif // !THINGSBOARD_ENABLE_PROGMEM
-
 /// ---------------------------------
 /// Constant strings in flash memory.
 /// ---------------------------------

--- a/src/ThingsBoardHttp.h
+++ b/src/ThingsBoardHttp.h
@@ -226,6 +226,14 @@ class ThingsBoardHttpSized {
       return getMessage(path, response);
     }
 
+    /// @brief Attempts to send a POST request over HTTP or HTTPS
+    /// @param path API path we want to send data to (example: /api/v1/$TOKEN/attributes)
+    /// @param json String containing our json key value pairs we want to attempt to send
+    /// @return Wheter sending the POST request was successful or not
+    inline const bool sendPostRequest(const char* path, const char* json) {
+      return postMessage(path, json);
+    }
+
     //----------------------------------------------------------------------------
     // Attribute API
 


### PR DESCRIPTION
@imbeacon I fixed the workflow corresponding to the previously created issue which should now be closed #121. They now compile again successfully.

Additionally I updated the documentation to reflect the newest changes and updated the `PlattformIO` config file to fetch the newest version of the `TBPubSubClient`.

Furthermore the workflows can now be started again, because they are currently paused and at least for the ESP8266 and ESP32 it is nice to see if a commit broke the examples.

Would be nice if this could be merged as 0.9.5