### PR TITLE
Integrated RPC Response as a JsonDocument

### DIFF
--- a/.github/workflows/arduino-compile.yml
+++ b/.github/workflows/arduino-compile.yml
@@ -73,4 +73,5 @@ jobs:
 
       - uses: arduino/report-size-deltas@v1
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           sketches-reports-source: ${{ env.SKETCHES_REPORTS_PATH }}/${{ env.SKETCHES_REPORTS_NAME }}

--- a/.github/workflows/esp32-compile.yml
+++ b/.github/workflows/esp32-compile.yml
@@ -96,4 +96,5 @@ jobs:
 
       - uses: arduino/report-size-deltas@v1
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           sketches-reports-source: ${{ env.SKETCHES_REPORTS_PATH }}/${{ env.SKETCHES_REPORTS_NAME }}

--- a/.github/workflows/esp8266-compile.yml
+++ b/.github/workflows/esp8266-compile.yml
@@ -94,4 +94,5 @@ jobs:
 
       - uses: arduino/report-size-deltas@v1
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           sketches-reports-source: ${{ env.SKETCHES_REPORTS_PATH }}/${{ env.SKETCHES_REPORTS_NAME }}

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 [![ESP8266](https://img.shields.io/badge/ESP-8266-blue.svg?style=flat-square)](https://www.espressif.com/en/products/socs/esp8266)
 [![GitHub release](https://img.shields.io/github/release/thingsboard/thingsboard-arduino-sdk/all.svg?style=flat-square)](https://github.com/thingsboard/thingsboard-arduino-sdk/releases/)
 [![GitHub downloads](https://img.shields.io/github/downloads/thingsboard/thingsboard-arduino-sdk/all.svg?style=flat-square)](https://github.com/thingsboard/thingsboard-arduino-sdk/releases/)
-[![Actions status](https://github.com/thingsboard/thingsboard-arduino-sdk/actions/workflows/arduino-compile.yml/badge.svg)](https://github.com/thingsboard/thingsboard-arduino-sdk/actions/workflows/arduino-compile.yml)
-[![Actions status](https://github.com/thingsboard/thingsboard-arduino-sdk/actions/workflows/esp32-compile.yml/badge.svg)](https://github.com/thingsboard/thingsboard-arduino-sdk/actions/workflows/esp32-compile.yml)
-[![Actions status](https://github.com/thingsboard/thingsboard-arduino-sdk/actions/workflows/esp8266-compile.yml/badge.svg)](https://github.com/thingsboard/thingsboard-arduino-sdk/actions/workflows/esp8266-compile.yml)
+[![Arduino actions status](https://github.com/thingsboard/thingsboard-arduino-sdk/actions/workflows/arduino-compile.yml/badge.svg)](https://github.com/thingsboard/thingsboard-arduino-sdk/actions/workflows/arduino-compile.yml)
+[![ESP32 actions status](https://github.com/thingsboard/thingsboard-arduino-sdk/actions/workflows/esp32-compile.yml/badge.svg)](https://github.com/thingsboard/thingsboard-arduino-sdk/actions/workflows/esp32-compile.yml)
+[![ESP8266 actions status](https://github.com/thingsboard/thingsboard-arduino-sdk/actions/workflows/esp8266-compile.yml/badge.svg)](https://github.com/thingsboard/thingsboard-arduino-sdk/actions/workflows/esp8266-compile.yml)
 ![GitHub stars](https://img.shields.io/github/stars/thingsboard/thingsboard-arduino-sdk?style=social)
 
 This library provides access to ThingsBoard platform over the `MQTT` protocol or alternatively over `HTTP/S`.
@@ -15,7 +15,7 @@ This library provides access to ThingsBoard platform over the `MQTT` protocol or
 ## Examples
 
 The SDK comes with a number of example sketches. See **Files --> Examples --> ThingsBoard** within the Arduino application.
-Please review the complete guide for `ESP32` Pico Kit GPIO control and `DHT22` sensor monitoring available [here](https://thingsboard.io/docs/samples/esp32/gpio-control-pico-kit-dht22-sensor/).
+Please review the complete guide for `ESP32` Pico Kit `GPIO` control and `DHT22` sensor monitoring available [here](https://thingsboard.io/docs/samples/esp32/gpio-control-pico-kit-dht22-sensor/).
 
 ## Installation
 
@@ -29,7 +29,7 @@ Following dependencies are installed automatically or must be installed, too:
 
 **Needs to be installed manually:**
  - [MbedTLS Library](https://github.com/Seeed-Studio/Seeed_Arduino_mbedtls) — needed to create hashes for the OTA update (`ESP8266` only, already included in `ESP32` base firmware).
- - [WiFiEsp Client](https://github.com/bportaluri/WiFiEsp) — needed when using an `Arduino Uno` in combination with an `ESP8266`.
+ - [WiFiEsp Client](https://github.com/bportaluri/WiFiEsp) — needed when using a `Arduino Uno` in combination with a `ESP8266`.
 
 ## Supported ThingsBoard Features
 
@@ -70,7 +70,7 @@ All constant variables are per default in flash memory to decrease the memory fo
 
 ### Dynamic ThingsBoard usage
 
-The received `JSON` payload, as well as the `sendAttributes` and` sendTelemetry` methods use the [`StaticJsonDocument`](https://arduinojson.org/v6/api/staticjsondocument/) by default, this furthemore requires the `MaxFieldsAmt` template argument passed in the constructor. To set the size the buffer should have, where bigger messages will cause not sent / received key-value pairs or failed deserializations.
+The received `JSON` payload, as well as the `sendAttributes` and `sendTelemetry` methods use the [`StaticJsonDocument`](https://arduinojson.org/v6/api/staticjsondocument/) by default, this furthermore requires the `MaxFieldsAmt` template argument passed in the constructor. To set the size the buffer should have, where bigger messages will cause not sent / received key-value pairs or failed de-/serialization.
 
 To remove the need for the `MaxFieldsAmt` template argument in the constructor and ensure the size the buffer should have is always enough to hold the sent or received messages, instead `#define THINGSBOARD_ENABLE_DYNAMIC 1` can be set before including the ThingsBoard header file. This makes the library use the [`DynamicJsonDocument`](https://arduinojson.org/v6/api/dynamicjsondocument/) instead of the default [`StaticJsonDocument`](https://arduinojson.org/v6/api/staticjsondocument/).
 
@@ -130,7 +130,7 @@ ThingsBoardSized<32> tb(espClient, 128);
 
 ## Tips and Tricks
 
-To use your own logger you have to create a class and pass it as third parameter `Logger` to your `ThingsBoardSized` class instance.
+To use your own logger you have to create a class and pass it as second template parameter `Logger` to your `ThingsBoardSized` class instance.
 
 **For example:**
 

--- a/examples/0002-arduino_rpc/0002-arduino_rpc.ino
+++ b/examples/0002-arduino_rpc/0002-arduino_rpc.ino
@@ -176,7 +176,9 @@ RPC_Response processTemperatureChange(const RPC_Data &data) {
   Serial.println(example_temperature);
 
   // Just an response example
-  return RPC_Response(RPC_RESPONSE_KEY, 42);
+  StaticJsonDocument<JSON_OBJECT_SIZE(1)> doc;
+  doc[RPC_RESPONSE_KEY] = 42;
+  return doc;
 }
 
 /// @brief Processes function for RPC call "example_set_switch"
@@ -198,7 +200,9 @@ RPC_Response processSwitchChange(const RPC_Data &data) {
   Serial.println(switch_state);
 
   // Just an response example
-  return RPC_Response(RPC_RESPONSE_KEY, 22.02);
+  StaticJsonDocument<JSON_OBJECT_SIZE(1)> doc;
+  doc[RPC_RESPONSE_KEY] = 22.02;
+  return doc;
 }
 
 const uint8_t callback_size = 2U;

--- a/examples/0010-esp8266_esp32_rpc/0010-esp8266_esp32_rpc.ino
+++ b/examples/0010-esp8266_esp32_rpc/0010-esp8266_esp32_rpc.ino
@@ -242,7 +242,9 @@ RPC_Response processTemperatureChange(const RPC_Data &data) {
   Serial.println(example_temperature);
 
   // Just an response example
-  return RPC_Response(RPC_RESPONSE_KEY, 42);
+  StaticJsonDocument<JSON_OBJECT_SIZE(1)> doc;
+  doc[RPC_RESPONSE_KEY] = 42;
+  return doc;
 }
 
 /// @brief Processes function for RPC call "example_set_switch"
@@ -268,7 +270,9 @@ RPC_Response processSwitchChange(const RPC_Data &data) {
   Serial.println(switch_state);
 
   // Just an response example
-  return RPC_Response(RPC_RESPONSE_KEY, 22.02);
+  StaticJsonDocument<JSON_OBJECT_SIZE(1)> doc;
+  doc[RPC_RESPONSE_KEY] = 22.02;
+  return doc;
 }
 
 const std::array<RPC_Callback, 2U> callbacks = {

--- a/library.json
+++ b/library.json
@@ -11,7 +11,7 @@
         "thingsboard/TBPubSubClient": "https://github.com/thingsboard/pubsubclient.git#v2.9.1",
         "arduino-libraries/ArduinoHttpClient" : "^0.4.0"
     },
-    "version": "0.9.7",
+    "version": "0.10.0",
     "examples": "examples/*/*.ino",
     "frameworks": "arduino",
     "license": "MIT"

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ThingsBoard
-version=0.9.7
+version=0.10.0
 author=ThingsBoard Team
 maintainer=ThingsBoard Team
 sentence=ThingsBoard library for Arduino.

--- a/src/RPC_Callback.h
+++ b/src/RPC_Callback.h
@@ -26,7 +26,7 @@ constexpr char RPC_CB_NULL[] = "Server-side RPC callback is NULL";
 #endif // THINGSBOARD_ENABLE_PROGMEM
 
 // Convenient aliases
-using RPC_Response = Telemetry;
+using RPC_Response = JsonVariant;
 // JSON variant const (read only twice as small as JSON variant), is used to communicate RPC parameters to the client
 using RPC_Data = const JsonVariantConst;
 
@@ -34,8 +34,8 @@ using RPC_Data = const JsonVariantConst;
 class RPC_Callback {
   public:
     /// @brief RPC callback signatures
-    using returnType = const RPC_Response;
-    using argumentType = const RPC_Data&;
+    using returnType = RPC_Response;
+    using argumentType = RPC_Data&;
 #if THINGSBOARD_ENABLE_STL
     using processFn = std::function<returnType(argumentType data)>;
 #else


### PR DESCRIPTION
The server-side RPC response now can be any JsonDocument instead of simply only a key-value pair.

This integrates the feature requests and therefore closes #79 and closes #32.

Furthermore because the commit contain breaking API changes the version number has been bumped to 0.10.0, to reflect that if the newest version is used, the API interactions have to be changed as well.

Examples have been adjusted accordingly to reflect the changes.

@imbeacon Would be nice if this could be merged.