### PR TITLE
Enable OTA only for C++ STL supported devices

### DIFF
--- a/examples/0003-esp8266_esp32_send_data/0003-esp8266_esp32_send_data.ino
+++ b/examples/0003-esp8266_esp32_send_data/0003-esp8266_esp32_send_data.ino
@@ -1,12 +1,14 @@
-#if defined(ESP8266)
+#ifdef ESP8266
 #include <ESP8266WiFi.h>
 // Disable PROGMEM because the ESP8266WiFi library,
 // does not support flash strings.
 #define THINGSBOARD_ENABLE_PROGMEM 0
-#elif defined(ESP32)
+#else
+#ifdef ESP32
 #include <WiFi.h>
 #include <WiFiClientSecure.h>
-#endif
+#endif // ESP32
+#endif // ESP8266
 
 
 // Sending data can either be done over MQTT and the PubSubClient

--- a/examples/0006-esp8266_esp32_process_shared_attribute_update/0006-esp8266_esp32_process_shared_attribute_update.ino
+++ b/examples/0006-esp8266_esp32_process_shared_attribute_update/0006-esp8266_esp32_process_shared_attribute_update.ino
@@ -1,12 +1,14 @@
-#if defined(ESP8266)
+#ifdef ESP8266
 #include <ESP8266WiFi.h>
 // Disable PROGMEM because the ESP8266WiFi library,
 // does not support flash strings.
 #define THINGSBOARD_ENABLE_PROGMEM 0
-#elif defined(ESP32)
+#else
+#ifdef ESP32
 #include <WiFi.h>
 #include <WiFiClientSecure.h>
-#endif
+#endif // ESP32
+#endif // ESP8266
 
 #include <ThingsBoard.h>
 

--- a/examples/0007-esp8266_esp32_claim_device/0007-esp8266_esp32_claim_device.ino
+++ b/examples/0007-esp8266_esp32_claim_device/0007-esp8266_esp32_claim_device.ino
@@ -1,12 +1,14 @@
-#if defined(ESP8266)
+#ifdef ESP8266
 #include <ESP8266WiFi.h>
 // Disable PROGMEM because the ESP8266WiFi library,
 // does not support flash strings.
 #define THINGSBOARD_ENABLE_PROGMEM 0
-#elif defined(ESP32)
+#else
+#ifdef ESP32
 #include <WiFi.h>
 #include <WiFiClientSecure.h>
-#endif
+#endif // ESP32
+#endif // ESP8266
 
 #include <ThingsBoard.h>
 

--- a/examples/0008-esp8266_esp32_provision_device/0008-esp8266_esp32_provision_device.ino
+++ b/examples/0008-esp8266_esp32_provision_device/0008-esp8266_esp32_provision_device.ino
@@ -1,12 +1,14 @@
-#if defined(ESP8266)
+#ifdef ESP8266
 #include <ESP8266WiFi.h>
 // Disable PROGMEM because the ESP8266WiFi library,
 // does not support flash strings.
 #define THINGSBOARD_ENABLE_PROGMEM 0
-#elif defined(ESP32)
+#else
+#ifdef ESP32
 #include <WiFi.h>
 #include <WiFiClientSecure.h>
-#endif
+#endif // ESP32
+#endif // ESP8266
 
 #include <ThingsBoard.h>
 

--- a/examples/0009-esp8266_esp32_process_OTA_MQTT/0009-esp8266_esp32_process_OTA_MQTT.ino
+++ b/examples/0009-esp8266_esp32_process_OTA_MQTT/0009-esp8266_esp32_process_OTA_MQTT.ino
@@ -1,12 +1,14 @@
-#if defined(ESP8266)
+#ifdef ESP8266
 #include <ESP8266WiFi.h>
 // Disable PROGMEM because the ESP8266WiFi library,
 // does not support flash strings.
 #define THINGSBOARD_ENABLE_PROGMEM 0
-#elif defined(ESP32)
+#else
+#ifdef ESP32
 #include <WiFi.h>
 #include <WiFiClientSecure.h>
-#endif
+#endif // ESP32
+#endif // ESP8266
 
 #include <ThingsBoard.h>
 
@@ -249,11 +251,14 @@ void updatedCallback(const bool& success) {
 #else
     Serial.println("Done, Reboot now");
 #endif
-#if defined(ESP8266)
+
+#ifdef ESP8266
     ESP.restart();
-#elif defined(ESP32)
+#else
+#ifdef ESP32
     esp_restart();
-#endif
+#endif // ESP32
+#endif // ESP8266
     return;
   }
 #if THINGSBOARD_ENABLE_PROGMEM

--- a/examples/0010-esp8266_esp32_rpc/0010-esp8266_esp32_rpc.ino
+++ b/examples/0010-esp8266_esp32_rpc/0010-esp8266_esp32_rpc.ino
@@ -1,12 +1,14 @@
-#if defined(ESP8266)
+#ifdef ESP8266
 #include <ESP8266WiFi.h>
 // Disable PROGMEM because the ESP8266WiFi library,
 // does not support flash strings.
 #define THINGSBOARD_ENABLE_PROGMEM 0
-#elif defined(ESP32)
+#else
+#ifdef ESP32
 #include <WiFi.h>
 #include <WiFiClientSecure.h>
-#endif
+#endif // ESP32
+#endif // ESP8266
 
 #include <ThingsBoard.h>
 

--- a/examples/0011-esp8266_esp32_subscribe_OTA_MQTT/0011-esp8266_esp32_subscribe_OTA_MQTT.ino
+++ b/examples/0011-esp8266_esp32_subscribe_OTA_MQTT/0011-esp8266_esp32_subscribe_OTA_MQTT.ino
@@ -1,12 +1,14 @@
-#if defined(ESP8266)
+#ifdef ESP8266
 #include <ESP8266WiFi.h>
 // Disable PROGMEM because the ESP8266WiFi library,
 // does not support flash strings.
 #define THINGSBOARD_ENABLE_PROGMEM 0
-#elif defined(ESP32)
+#else
+#ifdef ESP32
 #include <WiFi.h>
 #include <WiFiClientSecure.h>
-#endif
+#endif // ESP32
+#endif // ESP8266
 
 #include <ThingsBoard.h>
 
@@ -249,11 +251,14 @@ void updatedCallback(const bool& success) {
 #else
     Serial.println("Done, Reboot now");
 #endif
-#if defined(ESP8266)
+
+#ifdef ESP8266
     ESP.restart();
-#elif defined(ESP32)
+#else
+#ifdef ESP32
     esp_restart();
-#endif
+#endif // ESP32
+#endif // ESP8266
     return;
   }
 #if THINGSBOARD_ENABLE_PROGMEM

--- a/examples/0012-esp8266_esp32_request_shared_attribute/0012-esp8266_esp32_request_shared_attribute.ino
+++ b/examples/0012-esp8266_esp32_request_shared_attribute/0012-esp8266_esp32_request_shared_attribute.ino
@@ -1,12 +1,14 @@
-#if defined(ESP8266)
+#ifdef ESP8266
 #include <ESP8266WiFi.h>
 // Disable PROGMEM because the ESP8266WiFi library,
 // does not support flash strings.
 #define THINGSBOARD_ENABLE_PROGMEM 0
-#elif defined(ESP32)
+#else
+#ifdef ESP32
 #include <WiFi.h>
 #include <WiFiClientSecure.h>
-#endif
+#endif // ESP32
+#endif // ESP8266
 
 #include <ThingsBoard.h>
 

--- a/examples/0013-esp8266_esp32_request_rpc/0013-esp8266_esp32_request_rpc.ino
+++ b/examples/0013-esp8266_esp32_request_rpc/0013-esp8266_esp32_request_rpc.ino
@@ -1,12 +1,14 @@
-#if defined(ESP8266)
+#ifdef ESP8266
 #include <ESP8266WiFi.h>
 // Disable PROGMEM because the ESP8266WiFi library,
 // does not support flash strings.
 #define THINGSBOARD_ENABLE_PROGMEM 0
-#elif defined(ESP32)
+#else
+#ifdef ESP32
 #include <WiFi.h>
 #include <WiFiClientSecure.h>
-#endif
+#endif // ESP32
+#endif // ESP8266
 
 #include <ThingsBoard.h>
 

--- a/library.json
+++ b/library.json
@@ -7,11 +7,11 @@
         "url": "https://github.com/thingsboard/thingsboard-arduino-sdk"
     },
     "dependencies": {
-        "bblanchon/ArduinoJson": "^6.21.1",
+        "bblanchon/ArduinoJson": "^6.21.2",
         "thingsboard/TBPubSubClient": "https://github.com/thingsboard/pubsubclient.git#v2.9.1",
         "arduino-libraries/ArduinoHttpClient" : "^0.4.0"
     },
-    "version": "0.10.1",
+    "version": "0.10.2",
     "examples": "examples/*/*.ino",
     "frameworks": "arduino",
     "license": "MIT"

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ThingsBoard
-version=0.10.1
+version=0.10.2
 author=ThingsBoard Team
 maintainer=ThingsBoard Team
 sentence=ThingsBoard library for Arduino.

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -30,6 +30,11 @@
 #    endif
 #  endif
 
+// Enable the usage of OTA (Over the air) updates, only possible with STL base functionality and when using ESP8266 or the ESP32
+#  ifndef THINGSBOARD_ENABLE_OTA
+#    define THINGSBOARD_ENABLE_OTA THINGSBOARD_ENABLE_STL && (defined(ESP8266) || defined(ESP32))
+#  endif
+
 // Enable the usage of the PROGMEM header for constants variables (variables are placed into flash memory instead of sram).
 #  ifdef __has_include
 #    if  __has_include(<pgmspace.h>)

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -32,7 +32,21 @@
 
 // Enable the usage of OTA (Over the air) updates, only possible with STL base functionality and when using ESP8266 or the ESP32
 #  ifndef THINGSBOARD_ENABLE_OTA
-#    define THINGSBOARD_ENABLE_OTA THINGSBOARD_ENABLE_STL && (defined(ESP8266) || defined(ESP32))
+#    ifdef ESP8266
+#      ifdef THINGSBOARD_ENABLE_STL
+#        define THINGSBOARD_ENABLE_OTA 1
+#      else
+#        define THINGSBOARD_ENABLE_OTA 0
+#      endif
+#    else
+#      ifdef ESP32
+#        ifdef THINGSBOARD_ENABLE_STL
+#          define THINGSBOARD_ENABLE_OTA 1
+#        else
+#          define THINGSBOARD_ENABLE_OTA 0
+#        endif
+#      endif
+#    endif
 #  endif
 
 // Enable the usage of the PROGMEM header for constants variables (variables are placed into flash memory instead of sram).

--- a/src/HashGenerator.cpp
+++ b/src/HashGenerator.cpp
@@ -1,4 +1,4 @@
-#if defined(ESP8266) || defined(ESP32)
+#if THINGSBOARD_ENABLE_OTA
 
 // Header include.
 #include <HashGenerator.h>
@@ -41,4 +41,4 @@ void HashGenerator::finish(unsigned char *hash) {
     mbedtls_md_finish(&m_ctx, hash);
 }
 
-#endif // defined(ESP8266) || defined(ESP32)
+#endif // THINGSBOARD_ENABLE_OTA

--- a/src/HashGenerator.cpp
+++ b/src/HashGenerator.cpp
@@ -1,8 +1,7 @@
-#if THINGSBOARD_ENABLE_OTA
-
 // Header include.
 #include <HashGenerator.h>
 
+#if THINGSBOARD_ENABLE_OTA
 // Library includes.
 #include <sstream>
 #include <iomanip>

--- a/src/HashGenerator.h
+++ b/src/HashGenerator.h
@@ -7,14 +7,17 @@
 #ifndef Hash_Generator_h
 #define Hash_Generator_h
 
+// Local includes.
+#include "Configuration.h"
+
 #if THINGSBOARD_ENABLE_OTA
 
 // Library includes.
-#if defined(ESP8266)
-#include <Seeed_mbedtls.h>
-#else
+#ifdef ESP32
 #include <mbedtls/md.h>
-#endif // defined(ESP8266)
+#else
+#include <Seeed_mbedtls.h>
+#endif // ESP32
 #include <string>
 
 /// @brief Allows generating a hash of the given type

--- a/src/HashGenerator.h
+++ b/src/HashGenerator.h
@@ -7,7 +7,7 @@
 #ifndef Hash_Generator_h
 #define Hash_Generator_h
 
-#if defined(ESP8266) || defined(ESP32)
+#if THINGSBOARD_ENABLE_OTA
 
 // Library includes.
 #if defined(ESP8266)
@@ -46,6 +46,6 @@ private:
     mbedtls_md_context_t m_ctx;
 };
 
-#endif // defined(ESP8266) || defined(ESP32)
+#endif // THINGSBOARD_ENABLE_OTA
 
 #endif // Hash_Generator_h

--- a/src/OTA_Update_Callback.h
+++ b/src/OTA_Update_Callback.h
@@ -7,10 +7,10 @@
 #ifndef OTA_Update_Callback_h
 #define OTA_Update_Callback_h
 
-#if THINGSBOARD_ENABLE_OTA
-
 // Local includes.
 #include "Configuration.h"
+
+#if THINGSBOARD_ENABLE_OTA
 
 // Library includes.
 #include <functional>

--- a/src/OTA_Update_Callback.h
+++ b/src/OTA_Update_Callback.h
@@ -7,7 +7,7 @@
 #ifndef OTA_Update_Callback_h
 #define OTA_Update_Callback_h
 
-#if defined(ESP8266) || defined(ESP32)
+#if THINGSBOARD_ENABLE_OTA
 
 // Local includes.
 #include "Configuration.h"
@@ -196,6 +196,6 @@ class OTA_Update_Callback {
     uint16_t        m_timeout;       // How long we maximum wait for each chunck to arrive
 };
 
-#endif // defined(ESP8266) || defined(ESP32)
+#endif // THINGSBOARD_ENABLE_OTA
 
 #endif // OTA_Update_Callback_h

--- a/src/Telemetry.h
+++ b/src/Telemetry.h
@@ -14,8 +14,6 @@
 #include <ArduinoJson.h>
 #if THINGSBOARD_ENABLE_STL
 #include <type_traits>
-#else
-#define ArduinoJsonNameSpace ArduinoJson::ARDUINOJSON_VERSION_NAMESPACE::detail
 #endif // THINGSBOARD_ENABLE_STL
 
 /// @brief Telemetry record class, allows to store different data using a common interface.
@@ -34,22 +32,14 @@ class Telemetry {
     template <typename T,
 #if THINGSBOARD_ENABLE_STL
               // Standard library is_integral, includes bool, char, signed char, unsigned char, short, unsigned short, int, unsigned int, long, unsigned long, long long, and unsigned long longy
-              typename std::enable_if<std::is_integral<T>::value && !std::is_same<T, bool>::value>::type* = nullptr>
+              typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
 #else
               // Workaround for ArduinoJson version after 6.21.0, to still be able to access internal enable_if and is_integral declarations, previously accessible with ARDUINOJSON_NAMESPACE
-              typename ArduinoJsonNameSpace::enable_if<ArduinoJsonNameSpace::is_integral<T>::value && !ArduinoJsonNameSpace::is_same<T, bool>::value>::type* = nullptr>
+              typename ArduinoJson::ARDUINOJSON_VERSION_NAMESPACE::detail::enable_if<ArduinoJson::ARDUINOJSON_VERSION_NAMESPACE::detail::is_integral<T>::value>::type* = nullptr>
 #endif // THINGSBOARD_ENABLE_STL
     inline Telemetry(const char *key, T val)
             : m_type(DataType::TYPE_INT), m_key(key), m_value()   {
         m_value.integer = val;
-    }
-
-    /// @brief Constructs telemetry record from boolean value
-    /// @param key Key of the key value pair we want to create
-    /// @param val Value of the key value pair we want to create
-    inline Telemetry(const char *key, bool val)
-            : m_type(DataType::TYPE_BOOL), m_key(key), m_value()  {
-        m_value.boolean = val;
     }
 
     /// @brief Constructs telemetry record from float value
@@ -80,10 +70,6 @@ class Telemetry {
     inline bool SerializeKeyValue(const JsonVariant &jsonObj) const {
       if (m_key) {
         switch (m_type) {
-          case DataType::TYPE_BOOL:
-            jsonObj[m_key] = m_value.boolean;
-            return true;
-            break;
           case DataType::TYPE_INT:
             jsonObj[m_key] = m_value.integer;
             return true;
@@ -104,9 +90,6 @@ class Telemetry {
       }
 
       switch (m_type) {
-        case DataType::TYPE_BOOL:
-          return jsonObj.set(m_value.boolean);
-          break;
         case DataType::TYPE_INT:
           return jsonObj.set(m_value.integer);
           break;
@@ -127,7 +110,6 @@ class Telemetry {
     // Data container
     union Data {
       const char  *str;
-      bool        boolean;
       int         integer;
       float       real;
     };
@@ -135,7 +117,6 @@ class Telemetry {
     // Data type inside a container
     enum class DataType: const uint8_t {
       TYPE_NONE,
-      TYPE_BOOL,
       TYPE_INT,
       TYPE_REAL,
       TYPE_STR

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -7,16 +7,6 @@
 #ifndef ThingsBoard_h
 #define ThingsBoard_h
 
-// Library includes.
-#include <stdarg.h>
-#include <TBPubSubClient.h>
-
-#if defined(ESP8266)
-#include <Updater.h>
-#elif defined(ESP32)
-#include <Update.h>
-#endif
-
 // Local includes.
 #include "Constants.h"
 #include "Vector.h"
@@ -29,6 +19,20 @@
 #include "RPC_Request_Callback.h"
 #include "Provision_Callback.h"
 #include "OTA_Update_Callback.h"
+
+// Library includes.
+#include <stdarg.h>
+#include <TBPubSubClient.h>
+
+#if THINGSBOARD_ENABLE_OTA
+#ifdef ESP8266
+#include <Updater.h>
+#else
+#ifdef ESP32
+#include <Update.h>
+#endif // ESP32
+#endif // ESP8266
+#endif // THINGSBOARD_ENABLE_OTA
 
 /// ---------------------------------
 /// Constant strings in flash memory.
@@ -2086,7 +2090,7 @@ class ThingsBoardSized {
           Firmware_Send_State(FW_STATE_FAILED, ERROR_UPDATE_BEGIN);
           // Ensure to call Update.abort after calling Update.begin even if it failed,
           // to make sure that any possibly started processes are stopped and freed.
-#if defined(ESP32)
+#ifdef ESP32
           Update.abort();
 #endif
           return;
@@ -2096,7 +2100,7 @@ class ThingsBoardSized {
       // Write received binary data to flash partition
       if (Update.write(payload, length) != length) {
         Logger::log(ERROR_UPDATE_WRITE);
-#if defined(ESP32)
+#ifdef ESP32
           Update.abort();
 #endif
         m_fwState = false;
@@ -2128,7 +2132,7 @@ class ThingsBoardSized {
       // if not we assume the binary data has been changed or not completly downloaded --> Firmware update failed
       if (m_fwChecksum.compare(calculatedHash) != 0) {
         Logger::log(CHKS_VER_FAILED);
-#if defined(ESP32)
+#ifdef ESP32
         Update.abort();
 #endif
         m_fwState = false;

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -234,7 +234,7 @@ constexpr char PROV_CRED_CLIENT_ID[] = "clientId";
 constexpr char PROV_CRED_HASH[] = "hash";
 #endif // THINGSBOARD_ENABLE_PROGMEM
 
-#if defined(ESP8266) || defined(ESP32)
+#if THINGSBOARD_ENABLE_OTA
 
 // Firmware topics.
 #if THINGSBOARD_ENABLE_PROGMEM
@@ -340,7 +340,7 @@ constexpr char FW_UPDATE_SUCCESS[] = "Update success";
 constexpr char RESETTING_FAILED[] = "Preparing for OTA firmware updates failed, attributes might be NULL";
 #endif // THINGSBOARD_ENABLE_PROGMEM
 
-#endif // defined(ESP8266) || defined(ESP32)
+#endif // THINGSBOARD_ENABLE_OTA
 
 #if THINGSBOARD_ENABLE_DYNAMIC
 /// @brief Wrapper around the PubSubClient to allow connecting and sending / retrieving data from ThingsBoard over the MQTT or MQTT with TLS/SSL protocol.
@@ -399,7 +399,7 @@ class ThingsBoardSized {
       , m_provisionCallback()
       , m_requestId(0U)
       , m_qos(enableQoS)
-#if defined(ESP8266) || defined(ESP32)
+#if THINGSBOARD_ENABLE_OTA
       , m_fwState(false)
       , m_fwCallback(nullptr)
       , m_fwSize(0U)
@@ -410,7 +410,7 @@ class ThingsBoardSized {
       , m_fwRequestCallback(m_fwSharedKeys.cbegin(), m_fwSharedKeys.cend(), std::bind(&ThingsBoardSized::Firmware_Shared_Attribute_Received, this, std::placeholders::_1))
       , m_fwUpdateCallback(m_fwSharedKeys.cbegin(), m_fwSharedKeys.cend(), std::bind(&ThingsBoardSized::Firmware_Shared_Attribute_Received, this, std::placeholders::_1))
       , m_fwChunkReceive(0U)
-#endif
+#endif // THINGSBOARD_ENABLE_OTA
     {
 #if !THINGSBOARD_ENABLE_STL
       m_subscribedInstance = this;
@@ -1163,7 +1163,7 @@ class ThingsBoardSized {
     //----------------------------------------------------------------------------
     // Firmware OTA API
 
-#if defined(ESP8266) || defined(ESP32)
+#if THINGSBOARD_ENABLE_OTA
 
     /// @brief Immediately starts a firmware update if firmware is assigned to the given device
     /// @param callback Callback method that will be called
@@ -1224,7 +1224,7 @@ class ThingsBoardSized {
       return sendTelemetryJson(currentFirmwareStateObject, JSON_STRING_SIZE(measureJson(currentFirmwareStateObject)));
     }
 
-#endif
+#endif // THINGSBOARD_ENABLE_OTA
 
     //----------------------------------------------------------------------------
     // Shared attributes API
@@ -1497,7 +1497,7 @@ class ThingsBoardSized {
       return m_client.unsubscribe(PROV_RESPONSE_TOPIC);
     }
 
-#if defined(ESP8266) || defined(ESP32)
+#if THINGSBOARD_ENABLE_OTA
 
     /// @brief Checks the included information in the callback,
     /// and attempts to sends the current device firmware information to the cloud
@@ -1742,7 +1742,7 @@ class ThingsBoardSized {
       Firmware_OTA_Unsubscribe();
     }
 
-#endif
+#endif // THINGSBOARD_ENABLE_OTA
 
     /// @brief Connects to the previously set ThingsBoard server, as the given client with the given access token
     /// @param access_token Access token that connects this device with a created device on the ThingsBoard server,
@@ -1762,9 +1762,9 @@ class ThingsBoardSized {
       this->Shared_Attributes_Unsubscribe(); // Cleanup all shared attributes subscriptions
       this->Attributes_Request_Unsubscribe(); // Cleanup all client-side or shared attributes requests
       this->Provision_Unsubscribe(); // Cleanup all provision subscriptions
-#if defined(ESP8266) || defined(ESP32)
+#if THINGSBOARD_ENABLE_OTA
       this->Firmware_OTA_Unsubscribe(); // Cleanup all firmware subscriptions
-#endif
+#endif // THINGSBOARD_ENABLE_OTA
       return connection_result;
     }
 
@@ -2059,7 +2059,7 @@ class ThingsBoardSized {
       m_client.publish(responseTopic, responsePayload, m_qos);
     }
 
-#if defined(ESP8266) || defined(ESP32)
+#if THINGSBOARD_ENABLE_OTA
 
     /// @brief Process callback that will be called upon firmware response arrival
     /// and is responsible for handling the payload and calling the appropriate previously subscribed callback
@@ -2148,7 +2148,7 @@ class ThingsBoardSized {
       Firmware_Send_State(FW_STATE_VERIFIED);
     }
 
-#endif
+#endif // THINGSBOARD_ENABLE_OTA
 
     /// @brief Process callback that will be called upon shared attribute update arrival
     /// and is responsible for handling the payload and calling the appropriate previously subscribed callbacks
@@ -2438,7 +2438,7 @@ class ThingsBoardSized {
     uint32_t m_requestId; // Allows nearly 4.3 million requests before wrapping back to 0.
     bool m_qos; // Whether QoS level 1 should be enabled or disabled (Resends the packet until the message was received and a PUBACK packet was returned).
 
-#if defined(ESP8266) || defined(ESP32)
+#if THINGSBOARD_ENABLE_OTA
 
     bool m_fwState;
     const OTA_Update_Callback* m_fwCallback;
@@ -2452,7 +2452,7 @@ class ThingsBoardSized {
     const Shared_Attribute_Callback m_fwUpdateCallback;
     uint16_t m_fwChunkReceive;
 
-#endif
+#endif // THINGSBOARD_ENABLE_OTA
 
     /// @brief MQTT callback that will be called if a publish message is received from the server
     /// @param topic Previously subscribed topic, we got the response over
@@ -2474,9 +2474,9 @@ class ThingsBoardSized {
       } else if (strncmp_P(PROV_RESPONSE_TOPIC, topic, strlen(PROV_RESPONSE_TOPIC)) == 0) {
         process_provisioning_response(topic, payload, length);
       } else if (strncmp_P(FIRMWARE_RESPONSE_TOPIC, topic, strlen(FIRMWARE_RESPONSE_TOPIC)) == 0) {
-#if defined(ESP8266) || defined(ESP32)
+#if THINGSBOARD_ENABLE_OTA
         process_firmware_response(topic, payload, length);
-#endif
+#endif // THINGSBOARD_ENABLE_OTA
       }
     }
 


### PR DESCRIPTION
C++ STL only currenlty works if both the C++ STL is supported and the ESP8266 and ESP32 is used. To ensure the device compiles OTA is now disabled for ESP devices that do not support the C++ STL.

Fixes #136.